### PR TITLE
ci: run every --self-test, and refuse one no workflow invokes

### DIFF
--- a/.github/workflows/contracts-lint.yml
+++ b/.github/workflows/contracts-lint.yml
@@ -101,6 +101,15 @@ jobs:
           files=(contracts/**/*.schema.json contracts/**/*.asyncapi.yaml contracts/**/*.openapi.yaml)
           if [ ${#files[@]} -eq 0 ]; then echo "::error::no contract files"; exit 1; fi
           python3 scripts/check-contract-refs-are-local.py "${files[@]}"
+      # The two red-probes below run the checkers against constructed inputs
+      # that MUST fail. Both checkers were invoked only by their live run, which
+      # proves they pass on a correct tree and not that they would fail on a
+      # broken one. The meta-gate proves each self-test is bound to its subject;
+      # it does not run them, and nothing else did.
+      - name: the ref-locality checker itself discriminates
+        run: python3 scripts/check-contract-refs-are-local.py --self-test
+      - name: the fan-in INV-1 checker itself discriminates
+        run: python3 scripts/check-audit-fanin-inv1.py --self-test
       - name: audit fan-in INV-1 (receive-only)
         run: python3 scripts/check-audit-fanin-inv1.py
       # The parser above proves each payload $ref resolves to a well-formed JSON

--- a/scripts/check-self-tests-are-bound.py
+++ b/scripts/check-self-tests-are-bound.py
@@ -106,6 +106,31 @@ def _registry_covers(root: pathlib.Path) -> list[str]:
     )
 
 
+def _self_tests_ci_never_runs(root: pathlib.Path) -> list[str]:
+    """Checkers carrying a --self-test that no workflow invokes.
+
+    This gate proves each self-test would NOTICE a broken checker. It does not
+    run them. Measured when this was written: two --self-tests --
+    check-audit-fanin-inv1 and check-contract-refs-are-local -- were invoked by
+    their live run only, so CI proved they pass on a correct tree and never that
+    they fail on a broken one. A red-probe nobody executes is a red-probe on
+    paper.
+    """
+    workflows = root / ".github" / "workflows"
+    if not workflows.is_dir():
+        return []
+    text = " ".join(
+        p.read_text(encoding="utf-8", errors="ignore")
+        for p in list(workflows.glob("*.yml")) + list(workflows.glob("*.yaml"))
+    )
+    return sorted(
+        p.name
+        for p in (root / "scripts").glob("check-*.py")
+        if "--self-test" in p.read_text(encoding="utf-8", errors="ignore")
+        and f"{p.name} --self-test" not in text
+    )
+
+
 def _self_test() -> int:
     failures = 0
 
@@ -129,6 +154,26 @@ def _self_test() -> int:
             sys.stderr.write("self-test FAIL: an unregistered checker was not reported\n")
         else:
             print("  ok: a checker missing from the registry is reported")
+
+        # _self_tests_ci_never_runs() on the same constructed tree. On this
+        # repository it returns empty once every step exists, so a stub of it
+        # would pass here unnoticed.
+        (base / ".github" / "workflows").mkdir(parents=True)
+        (base / "scripts" / "check-probe.py").write_text("--self-test\n", encoding="utf-8")
+        (base / ".github" / "workflows" / "w.yml").write_text("run: nothing\n", encoding="utf-8")
+        if "check-probe.py" not in _self_tests_ci_never_runs(base):
+            failures += 1
+            sys.stderr.write("self-test FAIL: a --self-test no workflow runs was not reported\n")
+        else:
+            print("  ok: a --self-test CI never invokes is reported")
+        (base / ".github" / "workflows" / "w.yml").write_text(
+            "run: python3 scripts/check-probe.py --self-test\n", encoding="utf-8"
+        )
+        if "check-probe.py" in _self_tests_ci_never_runs(base):
+            failures += 1
+            sys.stderr.write("self-test FAIL: an invoked --self-test was still reported\n")
+        else:
+            print("  ok: a --self-test a workflow invokes is accepted")
 
     cases = [
         ("a list-returning function is stubbed to []", "def f(x) -> list[str]:\n    return [1]\n", "f", "return []"),
@@ -177,6 +222,17 @@ def main(argv: list[str] | None = None) -> int:
                 "cover. Register it with the function whose emptiness means "
                 "'found nothing', or the claim that every checker is bound is "
                 "true only of the ones listed.",
+                file=sys.stderr,
+            )
+        return 1
+
+    unrun = _self_tests_ci_never_runs(root)
+    if unrun:
+        for name in unrun:
+            print(
+                f"::error::{name} carries a --self-test that no workflow runs. Its "
+                "live invocation proves it passes on a correct tree, never that it "
+                "fails on a broken one -- add a step invoking it.",
                 file=sys.stderr,
             )
         return 1


### PR DESCRIPTION
ci: run every --self-test, and refuse one no workflow invokes

Two checkers carried a --self-test that CI never ran:
check-audit-fanin-inv1 and check-contract-refs-are-local. Both were invoked by
their live run only, which proves they pass on a correct tree and never that
they fail on a broken one. A red-probe nobody executes is a red-probe on paper.

Found by asking the meta-gate's own question of a different registry. It proves
each self-test is BOUND to its subject; it does not run them, and after #514
nothing else checked that CI did.

Two steps added, and the property is now enforced rather than restored: a
checker whose --self-test no workflow invokes is a blocking error. Probed by
deleting one of the new steps -- exit 1 -- and restoring it -- exit 0.

Two self-test cases drive _self_tests_ci_never_runs() over a constructed tree,
because on this repository it returns empty once every step exists and a stub
would pass unnoticed here. Stubbing it reds the self-test. 12 of 12 bound.


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Bug Fixes**
  * Improved validation of automated checks to ensure all registered self-tests are executed in CI.
  * Added safeguards that flag missing self-test workflow invocations.

* **Tests**
  * Added CI self-tests for local reference validation and audit fan-in validation.
  * Expanded self-test coverage to verify detection of unbound checks.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->