### PR TITLE
docs(nfrs): canon counted three readiness legs, the gate measures four

### DIFF
--- a/docs/architecture/manifesto/02-nfrs.md
+++ b/docs/architecture/manifesto/02-nfrs.md
@@ -212,9 +212,10 @@ Scope: determinism, replay, and reproducibility properties of the agent loop. Fu
 
 ### Deployment-readiness claim
 
-The three properties this architecture exists to establish — proven isolation,
-an auditable supply chain, and a canon where every decision is recorded and
-checkable — are each covered by the NFRs above and each carry their own gate.
+The four properties this architecture exists to establish — proven isolation,
+an auditable supply chain, a verified release path, and a canon where every
+decision is recorded and checkable — are each covered by the NFRs above and
+each carry their own gate.
 The claim that they hold TOGETHER is answered by measurement rather than by this
 paragraph:
 
@@ -226,7 +227,7 @@ python3 scripts/check-readiness-claim.py
 `check-readiness-claim.py` reads the DEFAULT branch of each component and looks
 for the symbol that carries each leg. A leg in an unmerged pull request is a
 property of a branch, not of the system, so it does not count. The script exits
-0 only when all three hold on what is shipped, 1 when any does not, and 2 when a
+0 only when all four hold on what is shipped, 1 when any does not, and 2 when a
 component cannot be read — unreadable is reported as unreadable, never as unmet.
 
 The number itself lives in the run log, not here. A count written into canon is

--- a/scripts/check-readiness-claim.py
+++ b/scripts/check-readiness-claim.py
@@ -36,6 +36,7 @@ from __future__ import annotations
 import argparse
 import json
 import os
+import pathlib
 import subprocess
 import sys
 import time
@@ -162,6 +163,43 @@ def _run(args: list[str], cwd: str | None = None) -> tuple[int, str, str]:
             return proc.returncode, proc.stdout, proc.stderr
         time.sleep(2 * (attempt + 1))
     return proc.returncode, proc.stdout, proc.stderr
+
+
+CANON_DOC = "docs/architecture/manifesto/02-nfrs.md"
+WORD_FOR = {3: "three", 4: "four", 5: "five", 6: "six"}
+
+
+def canon_leg_count_matches(root, measured: int) -> str | None:
+    """None when canon's readiness section counts the same legs this measures.
+
+    Found by reading both: the section said "The three properties this
+    architecture exists to establish" and named proven isolation, an auditable
+    supply chain and a checkable canon, while this script has measured four legs
+    since #116 added the verified release path. The gate was checking more than
+    the canon claimed, which is the safer direction and still a drift -- the
+    number in prose is the one a reader trusts.
+
+    Counting rather than matching leg names: canon writes the last leg as "a
+    canon where every decision is recorded and checkable", so a string compare
+    would report a false gap on wording.
+    """
+    doc = (root / CANON_DOC)
+    if not doc.is_file():
+        return None
+    text = doc.read_text(encoding="utf-8")
+    want = WORD_FOR.get(measured)
+    if want is None:
+        return None
+    if f"The {want} properties this architecture exists to establish" in text:
+        return None
+    import re
+
+    said = re.search(r"The (\w+) properties this architecture exists to establish", text)
+    return (
+        f"canon says '{said.group(1)}' properties, this script measures {measured}"
+        if said
+        else "canon's readiness section no longer states a property count"
+    )
 
 
 def leg_holds(leg: dict) -> bool:
@@ -1029,6 +1067,13 @@ def main(argv: list[str] | None = None) -> int:
                     )
         held = sum(1 for r in results if r["holds"])
         print()
+        drift = canon_leg_count_matches(pathlib.Path("."), len(results))
+        if drift:
+            print(
+                f"::notice::{drift}. The gate is the answer, but the number a reader "
+                f"trusts is the one in canon -- keep the readiness section's count in "
+                f"step with the legs measured here."
+            )
         if held == len(results):
             print(
                 "The deployment-readiness claim holds on the shipped branches: "


### PR DESCRIPTION
docs(nfrs): canon counted three readiness legs, the gate measures four

The readiness section opened "The three properties this architecture exists to
establish" and named proven isolation, an auditable supply chain and a checkable
canon. check-readiness-claim.py has measured four legs since #116 added the
verified release path -- which appears nowhere in docs/architecture/: grep
returns zero.

The gate was checking more than canon claimed. That is the safer direction and
still drift: the number a reader trusts is the one in prose, and canon is what a
reviewer reads when deciding whether the claim covers what they care about.

Canon now says four, and the exit-code sentence with it ("all four hold").

A count in prose goes stale the same way it just did, so the script reports when
the two disagree. It compares the COUNT, not the leg names: canon writes the
last leg as "a canon where every decision is recorded and checkable", and a
string compare would report a false gap on wording. Probed -- reverting canon to
"three" emits `canon says 'three' properties, this script measures 4`,
restoring clears it.

Report-only. A mismatch means canon needs an edit, which no CI run can perform,
and blocking would red every PR for a condition no PR can fix.

Re-verified while here that the claim itself is not vacuous: breaking one leg's
evidence symbol drops it to 3 of 4 and exits 1; restoring exits 0.


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

- **Documentation**
  - Updated deployment-readiness criteria to include a verified release path, expanding the requirements from three properties to four.

- **Bug Fixes**
  - Readiness checks now require all four properties to pass.
  - Added detection and notification when the documented property count differs from the measured checks.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->