### PR TITLE
test(readiness): bind every leg's symbol, in both directions

### DIFF
--- a/scripts/check-readiness-claim.py
+++ b/scripts/check-readiness-claim.py
@@ -751,6 +751,60 @@ def _self_test() -> int:
     else:
         print("  ok: MERGE_ORDER covers exactly the delivering PRs")
 
+    # Every leg's evidence must DISCRIMINATE, not merely be present. The ten
+    # cases above drive constructed branches and the table's shape; none of them
+    # touches a real symbol, so a leg whose evidence had quietly stopped
+    # matching -- a rename upstream, a string that now appears in a comment --
+    # would go unnoticed here and be caught only by someone mutating the table
+    # by hand.
+    #
+    # Two directions, because each alone passes on a broken table. Substituting
+    # an ABSENT symbol must flip the leg -- that catches a leg wired to nothing.
+    # It does not catch the opposite: an evidence string so short it matches
+    # everywhere ("e") still flips under substitution, because the substitute is
+    # absent either way. Measured -- replacing `func AdmitImageRef` with `e` left
+    # this block green. So a leg must ALSO fail to hold when its symbol is
+    # replaced by one that is present in every file.
+    # A symbol must not match text that is not the property. Probed against a
+    # line no component contains: an evidence string that hits it identifies
+    # prose rather than code. "e" matches; "func AdmitImageRef" does not.
+    import re as _re
+
+    decoy = "the quick brown fox jumps over the lazy dog 0123456789"
+    for leg in LEGS:
+        for field in ("evidence", "wired"):
+            value = leg.get(field)
+            if not value:
+                continue
+            try:
+                hits = bool(_re.search(value, decoy))
+            except _re.error:
+                hits = value in decoy
+            if hits:
+                failures.append(
+                    f"{leg['leg']}: {field} {value!r} matches arbitrary prose -- "
+                    f"it identifies text, not the property"
+                )
+    for leg in LEGS:
+        for field in ("evidence", "wired"):
+            value = leg.get(field)
+            if not value:
+                continue  # a test needs no call site; that is recorded on the leg
+            broken = dict(leg)
+            broken[field] = "zzz_no_such_symbol_" + field
+            try:
+                held = leg_holds(broken)
+            except Unreadable:
+                print(f"  ok: {leg['leg']}/{field} -> unreadable is not a pass")
+                continue
+            if held:
+                failures.append(
+                    f"{leg['leg']}: substituting an absent {field} still holds -- "
+                    f"the symbol is not what the leg is measuring"
+                )
+            else:
+                print(f"  ok: {leg['leg']}/{field} flips when the symbol is absent")
+
     for f in failures:
         print(f"FAIL {f}")
     if failures:

--- a/scripts/check-readiness-claim.py
+++ b/scripts/check-readiness-claim.py
@@ -785,6 +785,7 @@ def _self_test() -> int:
                     f"{leg['leg']}: {field} {value!r} matches arbitrary prose -- "
                     f"it identifies text, not the property"
                 )
+    unreadable_legs: list[str] = []
     for leg in LEGS:
         for field in ("evidence", "wired"):
             value = leg.get(field)
@@ -795,7 +796,13 @@ def _self_test() -> int:
             try:
                 held = leg_holds(broken)
             except Unreadable:
-                print(f"  ok: {leg['leg']}/{field} -> unreadable is not a pass")
+                # NOT a pass. Measured on CI, where the sibling repository is
+                # unreachable from the runner: all seven substitutions raised
+                # Unreadable and the block printed seven "ok" lines while
+                # asserting nothing. Locally the same seven flip. A case that
+                # reports success on the environment that cannot run it is the
+                # fake-green this file exists to refuse, so say so instead.
+                unreadable_legs.append(f"{leg['leg']}/{field}")
                 continue
             if held:
                 failures.append(
@@ -804,6 +811,17 @@ def _self_test() -> int:
                 )
             else:
                 print(f"  ok: {leg['leg']}/{field} flips when the symbol is absent")
+
+    if unreadable_legs:
+        # Reported, not failed: on a runner without access to the sibling
+        # repositories this is the environment, not a defect. Reported rather
+        # than silent, because "17 cases passed" read the same in both places
+        # while seven of them asserted nothing.
+        print(
+            f"::notice::{len(unreadable_legs)} leg symbol(s) could not be probed here -- "
+            f"the component was unreadable, so their binding is UNVERIFIED on this "
+            f"run rather than confirmed: {', '.join(unreadable_legs)}"
+        )
 
     for f in failures:
         print(f"FAIL {f}")


### PR DESCRIPTION
test(readiness): bind every leg's symbol, in both directions

The ten self-test cases drove constructed branches and the table's shape. None
touched a real symbol: grepping the self-test output for AdmitUIDMap,
AdmitImageRef, ghcr-guest or TestEveryDecision returned zero. So a leg whose
evidence had quietly stopped matching -- a rename upstream, a string that now
lives in a comment -- was caught only by someone mutating the table by hand,
which is what I had just been doing.

Seven symbols are now checked per leg and per field, and each is checked twice
because one direction alone passes on a broken table.

Substituting an ABSENT symbol must flip the leg. That catches a leg wired to
nothing. It does not catch the opposite, and I found that by probing rather
than by reading: replacing `func AdmitImageRef` with `e` -- a string present in
every file -- left the block green, because the substitute is absent either way.

So a symbol must also fail to match arbitrary prose. Probed against a decoy
line no component contains: `e` matches it, `func AdmitImageRef` does not. With
the vacuous evidence in place the self-test now exits 1 naming the leg and the
field; restoring exits 0.

17 cases. Meta-gate 12 of 12.


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

* **Bug Fixes**
  * Improved readiness validation to reject missing or unrelated evidence markers.
  * Added clearer reporting for checks that fail or cannot be verified.
  * Added safe handling for invalid pattern definitions.
  * Expanded validation coverage to ensure readiness checks distinguish valid evidence from similar, unrelated text.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->