### PR TITLE
ci: a file that does not parse is not a file with no findings

### DIFF
--- a/scripts/check-no-vendor-sdk.py
+++ b/scripts/check-no-vendor-sdk.py
@@ -135,7 +135,13 @@ def vendor_imports(source: str) -> list[tuple[int, str]]:
     try:
         tree = ast.parse(source)
     except SyntaxError:
-        return []
+        # A file that does not parse is a file whose imports were not read, and
+        # returning [] states the opposite. Measured: a source carrying
+        # `import anthropic` plus a syntax error exits 0, while the same import
+        # in a valid file exits 1 -- breaking the syntax hid the violation.
+        # Reported through the findings channel so it cannot pass unnoticed;
+        # line 0 because there is no line.
+        return [(0, "<unparseable: imports not read>")]
     found: list[tuple[int, str]] = []
     for node in ast.walk(tree):
         if isinstance(node, ast.Import):
@@ -192,6 +198,10 @@ def _endpoint_self_test() -> int:
 
 def _self_test() -> int:
     cases = [
+        # An unparseable file is reported, not read as clean. Without this a
+        # syntax error hides every import in the file: `import anthropic` plus
+        # a broken def exited 0 before this landed.
+        ("an unparseable source is reported", "import anthropic\ndef broken(:\n", 1),
         ("a plain import is caught", "import openai\n", 1),
         ("a from-import is caught", "from anthropic import Anthropic\n", 1),
         ("a submodule is caught", "import google.generativeai as genai\n", 1),
@@ -204,7 +214,9 @@ def _self_test() -> int:
         # A local module whose name merely begins with a vendor's.
         ("a same-prefix local module is not a vendor", "import openaiwrapper\n", 0),
         ("unrelated imports pass", "import json\nfrom pathlib import Path\n", 0),
-        ("unparseable source yields nothing rather than crashing", "def (\n", 0),
+        # Was "yields nothing rather than crashing", asserting the behaviour
+        # that hid a violation: not crashing is right, reporting nothing is not.
+        ("unparseable source reports rather than crashing", "def (\n", 1),
     ]
     failures = 0
     for name, source, want in cases:

--- a/scripts/check-pin-policy.py
+++ b/scripts/check-pin-policy.py
@@ -114,7 +114,12 @@ def undeclared_permissions(text: str) -> list[str]:
     try:
         doc = yaml.safe_load(text)
     except yaml.YAMLError:
-        return []
+        # Same shape as the vendor-SDK parser: a file that does not parse is a
+        # file whose jobs were not read, and [] claims they all declare their
+        # authority. Named through the findings channel instead. Milder than
+        # the vendor case -- an unparseable workflow reds its own run -- but
+        # this check must not certify what it could not look at.
+        return ["<unparseable: jobs not read>"]
     if not isinstance(doc, dict) or doc.get("permissions") is not None:
         return []
     return sorted(
@@ -226,6 +231,12 @@ def _self_test() -> int:
         # Token authority. The negative cases matter: a rule that flagged a job
         # whose file declares permissions at the top would report eleven false
         # findings on this repository.
+        (
+            "an unparseable workflow is reported, not called clean",
+            "name: x\non:\n bad: [unclosed\n",
+            undeclared_permissions,
+            True,
+        ),
         (
             "a job with no permissions at either level is caught",
             "name: w\non:\n  pull_request:\njobs:\n  a:\n    steps: []\n",


### PR DESCRIPTION
ci: a file that does not parse is not a file with no findings

Continued the sweep from #520 with a second shape: a handler that RETURNS a
clean value on failure. Three sites, one of them already justified in its own
comment (the readiness delivery decoration, which is a report on a verdict
main() has already reached). Two were not.

vendor_imports() returned [] on SyntaxError, which says "this file imports no
vendor SDK" about a file whose imports were never read. Measured:

    import anthropic + a syntax error  -> exit 0
    the same import, valid syntax      -> exit 1

Breaking the syntax hid the violation. It now reports through the findings
channel, so the file is named rather than skipped.

undeclared_permissions() had the same shape on YAML and is milder -- an
unparseable workflow reds its own run -- but the check must not certify jobs it
could not read either.

One existing self-test case asserted the old behaviour outright:
"unparseable source yields nothing rather than crashing", expecting 0. It went
red when the behaviour changed, which is what a bound case should do. Not
crashing is the part worth keeping; reporting nothing is not, so it is now
"reports rather than crashing", expecting 1.

Both self-tests carry a case for the parse failure. Meta-gate 12 of 12.


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

- **Bug Fixes**
  - Improved security and policy checks to flag files that cannot be parsed, rather than incorrectly treating them as valid.
  - Unreadable source files now generate vendor-import findings.
  - Invalid workflow configuration files now generate explicit permission-policy findings.

- **Tests**
  - Added coverage to verify that malformed source and workflow files are consistently reported as failures.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->