### PR TITLE
fix(nfr-coverage): measure whether a script is invoked, do not assume it

### DIFF
--- a/scripts/check-nfr-coverage.py
+++ b/scripts/check-nfr-coverage.py
@@ -164,12 +164,30 @@ def unreachable_on_canon(root: pathlib.Path, hits: dict[str, list[str]]) -> dict
         for rel in files:
             if rel.startswith(".github/workflows/"):
                 reachable |= fires.get(pathlib.Path(rel).name, False)
-            elif rel.startswith("scripts/"):
-                # scripts are invoked by contracts-lint, which covers canon
-                reachable |= True
             else:
-                # a tests/ file runs only if a workflow that fires invokes it
-                reachable |= any(fires.get(w, False) for w, body in bodies.items() if rel in body)
+                # Everything else -- scripts/ and tests/ alike -- is reachable
+                # only if a workflow that FIRES on canon invokes it. This used
+                # to shortcut scripts/ to True on the grounds that
+                # contracts-lint runs them, which stopped being true when the
+                # nfr-gates job moved to its own workflow (#511) and was never
+                # true of every file: scripts/apply-layer0-protection.sh is
+                # invoked by NO workflow -- it is the manual applier -- yet it
+                # is cited as evidence by NFR-SEC-88 and NFR-SEC-89.
+                #
+                # Not a live fake-green: both also cite a script CI does run,
+                # so the verdict is unchanged today. The assumption is what was
+                # wrong, and an assumption that happens to hold is the kind
+                # this file exists to replace with a measurement.
+                # Matched against RUN LINES, not the whole file. A mention in a
+                # comment is not an invocation: check-pin-policy.py is named in
+                # comments in security.yml and supply-chain.yml, and a
+                # substring search over the body counted those as callers --
+                # the same text-predicate trap this repository keeps finding.
+                reachable |= any(
+                    fires.get(w, False)
+                    and any(rel in line and not line.lstrip().startswith("#") for line in body.splitlines())
+                    for w, body in bodies.items()
+                )
         if not reachable:
             stranded[nid] = files
     return stranded


### PR DESCRIPTION
fix(nfr-coverage): measure whether a script is invoked, do not assume it

Reachability shortcut everything under scripts/ to True, on the stated grounds
that contracts-lint runs them. That stopped being true when the nfr-gates job
moved to its own workflow (#511), and it was never true of every file:
scripts/apply-layer0-protection.sh is the manual applier, invoked by NO
workflow, and it is cited as evidence by NFR-SEC-88 and NFR-SEC-89.

Not a live fake-green -- both also cite a script CI does run, so the verdict is
unchanged. The assumption was the defect, and an assumption that happens to
hold is what this file exists to replace with a measurement.

The first fix was still wrong, and the probe caught it rather than review. It
matched the script path against the whole workflow BODY, so a mention in a
comment counted as an invocation: check-pin-policy.py is named in comments in
security.yml and supply-chain.yml. Under that rule, removing every real
invocation left the NFR armed. Matching now skips comment lines, and the same
mutation reports STRANDED.

Probed end to end: as committed, one stranded id (NFR-SEC-15, unchanged from
before). Strip check-pin-policy's invocation and its workflow citation, leaving
only the comments, and NFR-SEC-18 joins it; restore and it leaves.
