### PR TITLE
ci: a commented-out step is not an invocation

### DIFF
--- a/scripts/check-nfr-coverage.py
+++ b/scripts/check-nfr-coverage.py
@@ -429,7 +429,15 @@ def _self_test() -> int:
     workflows = pathlib.Path(__file__).resolve().parents[1] / ".github/workflows"
     passed: list[int] = []
     for wf in sorted(workflows.glob("*.yml")) + sorted(workflows.glob("*.yaml")):
-        text = wf.read_text(encoding="utf-8")
+        # Executable lines only. A commented-out caller carries the same text,
+        # and counting it means this assertion answers for a step nobody runs
+        # -- measured by prefixing the real `--min-armed 11` step with `#`,
+        # after which the self-test still exited 0.
+        text = "\n".join(
+            line
+            for line in wf.read_text(encoding="utf-8").splitlines()
+            if not line.lstrip().startswith("#")
+        )
         passed += [
             int(part.split()[0])
             for part in text.split("--min-armed ")[1:]

--- a/scripts/check-self-tests-are-bound.py
+++ b/scripts/check-self-tests-are-bound.py
@@ -123,11 +123,21 @@ def _self_tests_ci_never_runs(root: pathlib.Path) -> list[str]:
         p.read_text(encoding="utf-8", errors="ignore")
         for p in list(workflows.glob("*.yml")) + list(workflows.glob("*.yaml"))
     )
+    # Executable lines only. Matching the whole file counted a COMMENTED-OUT
+    # invocation as a live one: measured by prefixing the real
+    # `run: python3 scripts/check-pin-policy.py --self-test` with `#`, after
+    # which this still exited 0. A gate whose subject is "does CI run this"
+    # must not accept the text of a step somebody disabled.
+    live = [
+        line
+        for line in text.splitlines()
+        if not line.lstrip().startswith("#")
+    ]
     return sorted(
         p.name
         for p in (root / "scripts").glob("check-*.py")
         if "--self-test" in p.read_text(encoding="utf-8", errors="ignore")
-        and f"{p.name} --self-test" not in text
+        and not any(f"{p.name} --self-test" in line for line in live)
     )
 
 
@@ -174,6 +184,17 @@ def _self_test() -> int:
             sys.stderr.write("self-test FAIL: an invoked --self-test was still reported\n")
         else:
             print("  ok: a --self-test a workflow invokes is accepted")
+
+        # A commented-out step is not an invocation. Matching the whole file
+        # counted one, so disabling a red-probe left this gate green.
+        (base / ".github" / "workflows" / "w.yml").write_text(
+            "  # run: python3 scripts/check-probe.py --self-test\n", encoding="utf-8"
+        )
+        if "check-probe.py" not in _self_tests_ci_never_runs(base):
+            failures += 1
+            sys.stderr.write("self-test FAIL: a commented-out invocation counted as live\n")
+        else:
+            print("  ok: a commented-out --self-test does not count as invoked")
 
     cases = [
         ("a list-returning function is stubbed to []", "def f(x) -> list[str]:\n    return [1]\n", "f", "return []"),


### PR DESCRIPTION
ci: a commented-out step is not an invocation

Swept for the shape #522 fixed -- a predicate matching a whole file when its
subject is something that executes. Four candidates, two real.

Both gates that ask "does CI run this" accepted a step somebody had disabled.
Measured by prefixing the real steps with `#`:

    check-self-tests-are-bound  # run: ... check-pin-policy.py --self-test   -> exit 0
    check-nfr-coverage          # run: ... --min-armed 11                    -> exit 0

So a red-probe could be commented out and the gate watching red-probes would
report everything invoked. Both now match executable lines only, and the same
mutation exits 1.

The other two candidates stay as they are, and that is the point of checking
rather than fixing every hit: check-readiness-claim's canon-count predicate
matches PROSE in the manifesto, and check-gates-are-required parses an
annotation string for forgeability. In both the text IS the subject.

One self-test case added for the commented-out invocation; the equivalent for
--min-armed is covered by the existing floor case, which now reads run lines.
Meta-gate 12 of 12.
