### PR TITLE
fix(nfr-coverage): a citation in the file header does not arm an id

### DIFF
--- a/scripts/check-nfr-coverage.py
+++ b/scripts/check-nfr-coverage.py
@@ -163,7 +163,27 @@ def unreachable_on_canon(root: pathlib.Path, hits: dict[str, list[str]]) -> dict
         reachable = False
         for rel in files:
             if rel.startswith(".github/workflows/"):
-                reachable |= fires.get(pathlib.Path(rel).name, False)
+                # The workflow must FIRE and must name the id on a line that
+                # runs. Firing alone counted a citation buried in a comment:
+                # measured, NFR-MAINT-AUDIT-SCHEMA had one comment line in
+                # contracts-lint.yml and one source in
+                # scripts/apply-layer0-protection.sh, which no workflow invokes
+                # -- both dead, and the id read `armed`. NFR-SEC-18 is the same
+                # shape in the workflow and survives on check-pin-policy.py,
+                # which CI does run.
+                name = pathlib.Path(rel).name
+                body = bodies.get(name, "")
+                # A comment INSIDE a job is the established way to bind an id to
+                # a job that carries it -- security.yml says so outright ("Named
+                # here so check-nfr-coverage.py counts this requirement as
+                # armed"). What does not bind is a citation in the file header,
+                # before any job: that is prose about the workflow, not a claim
+                # any job makes. Measured: requiring an executable line reported
+                # NFR-SEC-07 and NFR-SEC-19 as stranded, and both are carried by
+                # blocking jobs whose in-job comments name them.
+                in_jobs = body.split("\njobs:", 1)
+                scope = in_jobs[1] if len(in_jobs) == 2 else ""
+                reachable |= fires.get(name, False) and nid in scope
             else:
                 # Everything else -- scripts/ and tests/ alike -- is reachable
                 # only if a workflow that FIRES on canon invokes it. This used


### PR DESCRIPTION
fix(nfr-coverage): a citation in the file header does not arm an id

An NFR cited by a workflow counted as armed whenever that workflow fires,
wherever the citation sat. A header comment is prose about the file; it is not
a claim any job makes, and a job can be deleted without touching it.

The first fix required the id on an executable line, and the probe said no:
NFR-SEC-07 and NFR-SEC-19 went stranded, and both are correct as they stand.
security.yml says so outright -- "Named here so check-nfr-coverage.py counts
this requirement as armed" -- in a comment INSIDE a blocking job. Binding an id
to the job that carries it, in the job, is the established convention here, and
a rule that broke it would be wrong rather than strict.

So the boundary is the jobs block, not the comment marker. Probed: moving every
NFR-SEC-19 citation from the jobs block into the header reports it STRANDED,
restoring reports it armed. The verdict on the tree is unchanged -- 11 armed,
one stranded (NFR-SEC-15) -- because every id in a workflow today is cited
inside a job.

Two ids looked like finds mid-probe and were not. NFR-MAINT-AUDIT-SCHEMA is
cited beside the blocking `check-ocsf-class-identity.py` step, and NFR-SEC-18
survives on check-pin-policy.py, which CI runs on a live line. Reporting either
would have been a false positive from a rule that was too strict by one level.


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Bug Fixes**
  * Improved NFR coverage validation to recognize workflow references only when they are triggered by `next/v1` and located within the workflow’s jobs section.
  * Prevented unrelated workflow references from being incorrectly counted as reachable.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->