### PR TITLE
ci(nfr): arm NFR-COMP-22 — the SBOM mechanism already exists and blocks

### DIFF
--- a/.github/workflows/gate3-rehearsal.yml
+++ b/.github/workflows/gate3-rehearsal.yml
@@ -173,6 +173,15 @@ jobs:
             -o spdx-json=sbom.spdx.json
           jq '(.packages // []) | length' sbom.spdx.json
 
+      # NFR-COMP-22 (EU Cyber Resilience Act baseline: SBOM mandate). Named
+      # here so check-nfr-coverage.py counts the requirement as armed, on the
+      # same terms as NFR-SEC-19 in security.yml: the id belongs beside the
+      # assertion that answers it, and this job blocks -- continue-on-error is
+      # unset and `release — gate 3 rehearsal` is a required context -- so the
+      # name is not decoration. What it claims is the SBOM half of that row:
+      # an SBOM is generated per release and a guard refuses one describing
+      # nothing. The 24-hour vulnerability-disclosure half has no mechanism
+      # here and is not claimed.
       - name: RED LEG - an SBOM describing nothing must stop the pipeline
         run: |
           # The same three conditions build.yml applies, run against fixtures

--- a/.github/workflows/nfr-gates.yml
+++ b/.github/workflows/nfr-gates.yml
@@ -179,7 +179,7 @@ jobs:
         # unarmed remainder: that is the state of the layer, no single PR can
         # move it, and a gate nobody can turn green is a gate that gets ignored.
         # The number on every run is the point.
-        run: python3 scripts/check-nfr-coverage.py --min-armed 11
+        run: python3 scripts/check-nfr-coverage.py --min-armed 12
 
       - name: gate enforcement across the platform (report-only until protection is on)
         # The github context reaches the script through env, never by

--- a/scripts/check-nfr-coverage.py
+++ b/scripts/check-nfr-coverage.py
@@ -88,7 +88,7 @@ import sys
 # that passes LESS is refused, because the only legitimate reason for the
 # number to fall is that an NFR genuinely stopped being checked -- and that is
 # what the coverage comparison already catches, loudly.
-COMMITTED_FLOOR = 11
+COMMITTED_FLOOR = 12
 
 # The unexplained count on the day it was first measured honestly. A ceiling
 # rather than a floor: this number must go DOWN, and a commit that raises it is


### PR DESCRIPTION
ci(nfr): arm NFR-COMP-22 — the SBOM mechanism already exists and blocks

Coverage has been 11 of 190 for the whole of this series while every commit
made the number more trustworthy rather than larger. This one moves it: 12.

NFR-COMP-22 (EU Cyber Resilience Act baseline, SBOM mandate) was excused by
mechanism -- its verification column says "per-release", and per-release was on
the absent list. It should not have been: gate3-rehearsal.yml generates an SPDX
SBOM with syft AND carries a red leg proving the guard refuses one describing
nothing (empty file, garbage, zero packages). The job sets no
continue-on-error and `release — gate 3 rehearsal` is a required context, so
the assertion blocks.

Found by reading the excused set rather than trusting it. Four other subjects
looked present and were not, which is why each was checked rather than
grepped: `runc` matched "truncate" in app.py, `kms` matched a minified
pdf.worker.min.js token, and `gvisor` appears only as an option in an issue
template. Only OIDC, SBOM and webhooks are real.

The id is named beside the step that answers it, on the NFR-SEC-19 convention.
The claim is scoped in the comment: the SBOM half of that row, not the 24-hour
vulnerability-disclosure half, which has no mechanism here.

Floor 11 -> 12, in the script and in the workflow. Probed: removing the
citation drops coverage to 11 and exits 1; restoring exits 0. The unexplained
ceiling is unchanged at 31 -- COMP-22 was never in that set, and I checked
rather than assumed.


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Quality & Compliance**
  * Increased the minimum required NFR coverage from 11 to 12 safeguards.
  * Added coverage tracking for the SBOM requirement, including validation that an empty SBOM is rejected.
  * Clarified that vulnerability disclosure coverage is outside this check.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->