### PR TITLE
ci(nfr): arm NFR-FLEX-13 by validating the chart across the range it claims

### DIFF
--- a/.github/workflows/helm.yml
+++ b/.github/workflows/helm.yml
@@ -124,8 +124,20 @@ jobs:
         run: |
           curl -sSL "https://github.com/yannh/kubeconform/releases/download/${KUBECONFORM_VERSION}/kubeconform-linux-amd64.tar.gz" \
             | sudo tar -xz -C /usr/local/bin kubeconform
-          kubeconform -strict -summary -kubernetes-version 1.30.0 /tmp/render-default.yaml
-          kubeconform -strict -summary -kubernetes-version 1.30.0 /tmp/render-runc.yaml
+          # NFR-FLEX-13 (k8s-distro portability: the chart installs on any
+          # conformant k8s >= 1.28 without flavour-specific edits). Its target
+          # column asks for a CI matrix and this validated one version, which
+          # answers "the chart is valid on 1.30" rather than the requirement.
+          # Both ends of the supported range are checked plus a mid point, so a
+          # manifest using an API removed after 1.28 or one not yet present in
+          # it fails here rather than at a customer's install. Named beside the
+          # assertion on the NFR-SEC-19 convention; this job blocks.
+          for kube in 1.28.0 1.30.0 1.32.0; do
+            echo "::group::kubeconform against k8s ${kube}"
+            kubeconform -strict -summary -kubernetes-version "${kube}" /tmp/render-default.yaml
+            kubeconform -strict -summary -kubernetes-version "${kube}" /tmp/render-runc.yaml
+            echo "::endgroup::"
+          done
 
   release:
     name: Publish chart to gh-pages

--- a/.github/workflows/nfr-gates.yml
+++ b/.github/workflows/nfr-gates.yml
@@ -179,7 +179,7 @@ jobs:
         # unarmed remainder: that is the state of the layer, no single PR can
         # move it, and a gate nobody can turn green is a gate that gets ignored.
         # The number on every run is the point.
-        run: python3 scripts/check-nfr-coverage.py --min-armed 12
+        run: python3 scripts/check-nfr-coverage.py --min-armed 13
 
       - name: gate enforcement across the platform (report-only until protection is on)
         # The github context reaches the script through env, never by

--- a/scripts/check-nfr-coverage.py
+++ b/scripts/check-nfr-coverage.py
@@ -101,12 +101,12 @@ import sys
 # that passes LESS is refused, because the only legitimate reason for the
 # number to fall is that an NFR genuinely stopped being checked -- and that is
 # what the coverage comparison already catches, loudly.
-COMMITTED_FLOOR = 12
+COMMITTED_FLOOR = 13
 
 # The unexplained count on the day it was first measured honestly. A ceiling
 # rather than a floor: this number must go DOWN, and a commit that raises it is
 # adding a requirement nobody accounted for.
-UNEXPLAINED_CEILING = 41
+UNEXPLAINED_CEILING = 40
 
 NFR_ID = re.compile(r"NFR-[A-Z]+-[A-Za-z0-9]+(?:-[A-Za-z0-9]+)*")
 MANIFESTO = "docs/architecture/manifesto/02-nfrs.md"


### PR DESCRIPTION
ci(nfr): arm NFR-FLEX-13 by validating the chart across the range it claims

The requirement is "Helm chart on any conformant k8s >= 1.28 without
flavour-specific edits", target column "CI matrix". helm.yml ran kubeconform
against 1.30.0 only, which answers "the chart is valid on 1.30" -- a different
and much weaker claim than the one the row makes.

Now both ends of the supported range plus a mid point: 1.28.0, 1.30.0, 1.32.0.
A manifest using an API removed after 1.28, or one not present in it, fails
here rather than at a customer's install.

Verified by running it, not by trusting the edit. Rendering the chart the way
CI does -- `-f examples/helm/standalone/values.yaml` -- and validating: 12
resources, valid on all three versions. My first attempt used `--set
secrets.mcpApiKey=` alone and the chart's own values schema refused it
(PUBLIC_BASE_URL minLength), which is the schema doing its job.

Red-probed so the green means something: a PodSecurityPolicy manifest, removed
from Kubernetes in 1.25, exits 1 on both 1.28 and 1.32. kubeconform can refuse.

Coverage 12 -> 13, floor with it, and the ceiling 41 -> 40. Probed: removing
the citation drops coverage to 12 and exits 1.


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Tests**
  * Kubernetes manifest validation now covers versions 1.28.0, 1.30.0, and 1.32.0 across standard and rendered manifests.
  * Increased the minimum required number of armed non-functional requirements from 12 to 13.
  * Tightened the limit for unexplained CI-gated requirements from 41 to 40.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->