### PR TITLE
feat(security): publish the disclosure record NFR-COMP-19 asks for, and gate it

### DIFF
--- a/.github/workflows/nfr-gates.yml
+++ b/.github/workflows/nfr-gates.yml
@@ -98,6 +98,18 @@ jobs:
         env:
           GH_TOKEN: ${{ github.token }}
         run: python3 scripts/check-readiness-claim.py || true
+      - name: the security.txt checker itself discriminates
+        run: python3 scripts/check-security-txt.py --self-test
+
+      # NFR-COMP-19 (public vulnerability-disclosure record). Named here so
+      # check-nfr-coverage.py counts the requirement as armed: this job blocks,
+      # and the assertion is that /.well-known/security.txt carries the RFC 9116
+      # fields AND has not expired. SECURITY.md answers a human reader; a
+      # scanner needs the record, and an expired record publishes a channel
+      # nobody has promised to watch.
+      - name: the disclosure record is machine-readable and current
+        run: python3 scripts/check-security-txt.py
+
       - name: the canon-trigger checker itself discriminates
         run: python3 scripts/check-gates-trigger-on-canon.py --self-test
 
@@ -179,7 +191,7 @@ jobs:
         # unarmed remainder: that is the state of the layer, no single PR can
         # move it, and a gate nobody can turn green is a gate that gets ignored.
         # The number on every run is the point.
-        run: python3 scripts/check-nfr-coverage.py --min-armed 13
+        run: python3 scripts/check-nfr-coverage.py --min-armed 14
 
       - name: gate enforcement across the platform (report-only until protection is on)
         # The github context reaches the script through env, never by

--- a/.well-known/security.txt
+++ b/.well-known/security.txt
@@ -1,0 +1,17 @@
+# SPDX-License-Identifier: FSL-1.1-Apache-2.0
+# Copyright (c) 2025 Open Computer Use Contributors
+#
+# RFC 9116. NFR-COMP-19 asks for a machine-readable disclosure record, and
+# SECURITY.md is prose: it carries the same contact in a form a scanner cannot
+# parse. Both exist because they answer different readers -- a person opening
+# the repository, and a tool looking for /.well-known/security.txt.
+#
+# Contact points at GitHub private vulnerability reporting rather than an
+# address, because that is the channel SECURITY.md already directs people to
+# and a second one would split reports between two places.
+
+Contact: https://github.com/Wide-Moat/open-computer-use/security/advisories/new
+Expires: 2027-01-01T00:00:00.000Z
+Preferred-Languages: en
+Canonical: https://github.com/Wide-Moat/open-computer-use/blob/main/.well-known/security.txt
+Policy: https://github.com/Wide-Moat/open-computer-use/blob/main/SECURITY.md

--- a/scripts/check-nfr-coverage.py
+++ b/scripts/check-nfr-coverage.py
@@ -101,12 +101,12 @@ import sys
 # that passes LESS is refused, because the only legitimate reason for the
 # number to fall is that an NFR genuinely stopped being checked -- and that is
 # what the coverage comparison already catches, loudly.
-COMMITTED_FLOOR = 13
+COMMITTED_FLOOR = 14
 
 # The unexplained count on the day it was first measured honestly. A ceiling
 # rather than a floor: this number must go DOWN, and a commit that raises it is
 # adding a requirement nobody accounted for.
-UNEXPLAINED_CEILING = 40
+UNEXPLAINED_CEILING = 39
 
 NFR_ID = re.compile(r"NFR-[A-Z]+-[A-Za-z0-9]+(?:-[A-Za-z0-9]+)*")
 MANIFESTO = "docs/architecture/manifesto/02-nfrs.md"

--- a/scripts/check-security-txt.py
+++ b/scripts/check-security-txt.py
@@ -1,0 +1,107 @@
+#!/usr/bin/env python3
+# SPDX-License-Identifier: FSL-1.1-Apache-2.0
+# Copyright (c) 2025 Open Computer Use Contributors
+#
+# NFR-COMP-19: the vulnerability-disclosure record is machine-readable and not
+# expired.
+#
+# SECURITY.md already carried the contact, in prose. A scanner looking for
+# /.well-known/security.txt found nothing, so the requirement was answered for
+# a human reader and not for the tool the RFC exists to serve.
+#
+# The interesting field is Expires. RFC 9116 makes it mandatory precisely
+# because a stale record is worse than none -- it publishes a channel nobody
+# watches. A file with a date in the past satisfies "the file exists" and fails
+# the requirement, which is why this checks the value rather than the presence.
+
+import datetime
+import re
+import sys
+from pathlib import Path
+
+RECORD = Path(".well-known/security.txt")
+REQUIRED_FIELDS = ("Contact", "Expires", "Canonical", "Policy")
+FIELD = re.compile(r"^([A-Za-z-]+):\s*(\S.*)$")
+
+
+def fields(text: str) -> dict[str, str]:
+    """Parse the record. Comment lines are not fields -- the RFC uses `#`."""
+    out: dict[str, str] = {}
+    for line in text.splitlines():
+        if line.lstrip().startswith("#"):
+            continue
+        match = FIELD.match(line.strip())
+        if match:
+            out.setdefault(match.group(1), match.group(2).strip())
+    return out
+
+
+def problems(text: str, today: datetime.date) -> list[str]:
+    """Reasons to refuse. Empty means the record answers NFR-COMP-19."""
+    found = fields(text)
+    out = [f"missing required field {name}" for name in REQUIRED_FIELDS if name not in found]
+    raw = found.get("Expires")
+    if raw:
+        try:
+            expires = datetime.datetime.fromisoformat(raw.replace("Z", "+00:00")).date()
+        except ValueError:
+            out.append(f"Expires is not an ISO 8601 timestamp: {raw!r}")
+        else:
+            if expires <= today:
+                out.append(
+                    f"Expires {expires} is in the past -- the record publishes a "
+                    f"channel nobody has promised to watch"
+                )
+    return out
+
+
+def self_test() -> int:
+    today = datetime.date(2026, 1, 1)
+    live = (
+        "Contact: https://x/report\nExpires: 2027-01-01T00:00:00.000Z\n"
+        "Canonical: https://x/security.txt\nPolicy: https://x/SECURITY.md\n"
+    )
+    cases = [
+        (live, 0, "a complete, unexpired record passes"),
+        (live.replace("2027", "2025"), 1, "an expired record is refused"),
+        (live.replace("Contact: https://x/report\n", ""), 1, "a missing Contact is refused"),
+        (live.replace("Expires: 2027-01-01T00:00:00.000Z", "Expires: soon"), 1,
+         "an unparseable Expires is refused"),
+        ("# Contact: https://x/report\n" + live.replace("Contact: https://x/report\n", ""), 1,
+         "a field commented out does not count"),
+    ]
+    bad = 0
+    for text, want, label in cases:
+        got = 1 if problems(text, today) else 0
+        ok = got == want
+        bad += 0 if ok else 1
+        print(f"  {'ok' if ok else 'FAIL'}: {label}")
+    if bad:
+        print(f"self-test: {bad} case(s) failed")
+        return 1
+    print(f"self-test ok: {len(cases)} cases")
+    return 0
+
+
+def main(argv: list[str]) -> int:
+    if argv and argv[0] == "--self-test":
+        return self_test()
+    root = Path(argv[0]) if argv else Path(".")
+    path = root / RECORD
+    if not path.is_file():
+        sys.stderr.write(
+            f"::error::{RECORD} is missing. NFR-COMP-19 asks for a machine-readable "
+            "disclosure record; SECURITY.md answers a human reader only.\n"
+        )
+        return 1
+    found = problems(path.read_text(encoding="utf-8"), datetime.date.today())
+    for problem in found:
+        sys.stderr.write(f"::error::{RECORD}: {problem}\n")
+    if found:
+        return 1
+    print(f"NFR-COMP-19: {RECORD} carries all {len(REQUIRED_FIELDS)} required fields and has not expired")
+    return 0
+
+
+if __name__ == "__main__":
+    sys.exit(main(sys.argv[1:]))

--- a/scripts/check-self-tests-are-bound.py
+++ b/scripts/check-self-tests-are-bound.py
@@ -46,6 +46,7 @@ SUBJECTS: dict[str, str] = {
     "check-readiness-claim.py": "leg_holds",
     "check-contract-refs-are-local.py": "check_file",
     "check-gates-trigger-on-canon.py": "findings",
+    "check-security-txt.py": "problems",
     # Added once the registry itself was measured against scripts/: these three
     # carried a --self-test and CI ran it, which proved the self-tests exist.
     # Nothing proved they would notice. Probed before registering -- stubbing


### PR DESCRIPTION
feat(security): publish the disclosure record NFR-COMP-19 asks for, and gate it

NFR-COMP-19 wants a machine-readable vulnerability-disclosure record --
`security.txt` plus a policy link. SECURITY.md carried the contact in prose:
45 lines, zero RFC 9116 fields, so a scanner looking for
/.well-known/security.txt found nothing. The requirement was answered for a
human reader and not for the tool the RFC exists to serve.

Both now exist and say the same thing. Contact points at GitHub private
vulnerability reporting rather than a second address, because SECURITY.md
already directs people there and splitting reports across two channels is
worse than one.

The gate checks the Expires value, not the file's presence. RFC 9116 makes
that field mandatory precisely because a stale record is worse than none: it
publishes a channel nobody has promised to watch. A checker satisfied by
existence would go green on a record that expired last year.

Probed on the real artefact rather than fixtures: expiring it exits 1, deleting
Policy exits 1, removing the file exits 1, restoring exits 0. Five self-test
cases including a commented-out field, which must not count -- the RFC uses `#`
and a naive parser would read a disabled line as a live one.

Coverage 13 -> 14, floor with it, ceiling 40 -> 39. Meta-gate 13 of 13; it
caught the missing --self-test step itself, which is what #515 built it to do.


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

- **New Features**
  - Added a machine-readable security contact record with vulnerability reporting details, expiration information, and security policy links.
  - Added validation to ensure the security record is present, complete, correctly formatted, and current.

- **Quality Improvements**
  - Strengthened release checks by requiring validated security documentation and increasing the minimum NFR coverage threshold.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->