### PR TITLE
ci(nfr): arm NFR-FLEX-14 — the frozen MCP version must be one the pin can speak

### DIFF
--- a/.github/workflows/nfr-gates.yml
+++ b/.github/workflows/nfr-gates.yml
@@ -98,6 +98,21 @@ jobs:
         env:
           GH_TOKEN: ${{ github.token }}
         run: python3 scripts/check-readiness-claim.py || true
+      - name: the MCP protocol checker itself discriminates
+        run: python3 scripts/check-mcp-protocol-version.py --self-test
+
+      # NFR-FLEX-14 (MCP is OCU's inbound wire protocol). The contract tree
+      # freezes a protocol version by directory name, and the server negotiates
+      # whatever the mcp pin supports -- nothing compared the two. Bump the pin
+      # to a release that drops the frozen version and every schema gate stays
+      # green while the contract describes a protocol the server cannot speak.
+      # Named here so the requirement counts as armed; this job blocks.
+      - name: the frozen MCP version is one the pin can speak
+        run: |
+          set -euo pipefail
+          pip install -q "$(grep -E '^mcp==' computer-use-server/requirements.txt)"
+          python3 scripts/check-mcp-protocol-version.py
+
       - name: the security.txt checker itself discriminates
         run: python3 scripts/check-security-txt.py --self-test
 
@@ -191,7 +206,7 @@ jobs:
         # unarmed remainder: that is the state of the layer, no single PR can
         # move it, and a gate nobody can turn green is a gate that gets ignored.
         # The number on every run is the point.
-        run: python3 scripts/check-nfr-coverage.py --min-armed 14
+        run: python3 scripts/check-nfr-coverage.py --min-armed 15
 
       - name: gate enforcement across the platform (report-only until protection is on)
         # The github context reaches the script through env, never by

--- a/scripts/check-mcp-protocol-version.py
+++ b/scripts/check-mcp-protocol-version.py
@@ -1,0 +1,129 @@
+#!/usr/bin/env python3
+# SPDX-License-Identifier: FSL-1.1-Apache-2.0
+# Copyright (c) 2025 Open Computer Use Contributors
+#
+# NFR-FLEX-14: MCP is OCU's inbound wire protocol, and the version the contract
+# freezes is one the pinned library can actually speak.
+#
+# The contract directory is named for a protocol version --
+# contracts/mcp/2025-06-18/ -- and nothing tied that name to the runtime. The
+# version is not written in OCU's code at all: it comes from the `mcp` pin in
+# computer-use-server/requirements.txt, whose SUPPORTED_PROTOCOL_VERSIONS list
+# decides what the server will negotiate.
+#
+# So the failure this catches is a silent one. Bump the pin to a release that
+# drops 2025-06-18 and the contract still parses, every schema gate stays green,
+# and the frozen surface describes a protocol the server can no longer speak.
+# Nothing else in the repository compares the two.
+#
+# Measured when this was written: mcp==1.27.0 supports
+# ['2024-11-05', '2025-03-26', '2025-06-18', '2025-11-25'], so the contract is
+# satisfiable today. The `2024-11-05` string in app.py is a documentation
+# EXAMPLE of an initialize request, not the version the server declares -- a
+# grep for the version would report a contradiction that does not exist.
+
+import re
+import sys
+from pathlib import Path
+
+CONTRACTS = Path("contracts/mcp")
+REQUIREMENTS = Path("computer-use-server/requirements.txt")
+VERSION_DIR = re.compile(r"^\d{4}-\d{2}-\d{2}$")
+
+
+def contract_versions(root: Path) -> list[str]:
+    """Protocol versions the contract tree freezes, from its directory names."""
+    base = root / CONTRACTS
+    if not base.is_dir():
+        return []
+    return sorted(p.name for p in base.iterdir() if p.is_dir() and VERSION_DIR.match(p.name))
+
+
+def pinned_mcp(root: Path) -> str | None:
+    """The mcp version requirements.txt pins, or None when it is not pinned."""
+    path = root / REQUIREMENTS
+    if not path.is_file():
+        return None
+    for line in path.read_text(encoding="utf-8").splitlines():
+        stripped = line.strip()
+        if stripped.startswith("#"):
+            continue
+        match = re.match(r"^mcp==([0-9][^\s#]*)", stripped)
+        if match:
+            return match.group(1)
+    return None
+
+
+def unsupported(contract: list[str], supported: list[str]) -> list[str]:
+    """Contract versions the library cannot speak. Empty means agreement."""
+    return sorted(v for v in contract if v not in supported)
+
+
+def self_test() -> int:
+    cases = [
+        (["2025-06-18"], ["2024-11-05", "2025-06-18"], [], "a contract version the library supports"),
+        (["2025-06-18"], ["2024-11-05", "2025-11-25"], ["2025-06-18"], "a version dropped by a bump"),
+        ([], ["2025-06-18"], [], "no contract directory is not a violation"),
+        (["2025-06-18", "2099-01-01"], ["2025-06-18"], ["2099-01-01"], "one of two is reported"),
+    ]
+    bad = 0
+    for contract, supported, want, label in cases:
+        got = unsupported(contract, supported)
+        ok = got == want
+        bad += 0 if ok else 1
+        print(f"  {'ok' if ok else 'FAIL'}: {label} -> {got or 'none'}")
+    if bad:
+        print(f"self-test: {bad} case(s) failed")
+        return 1
+    print(f"self-test ok: {len(cases)} cases")
+    return 0
+
+
+def main(argv: list[str]) -> int:
+    if argv and argv[0] == "--self-test":
+        return self_test()
+    root = Path(argv[0]) if argv else Path(".")
+
+    versions = contract_versions(root)
+    if not versions:
+        print(f"::notice::no versioned directory under {CONTRACTS} -- nothing to compare")
+        return 0
+
+    pin = pinned_mcp(root)
+    if pin is None:
+        sys.stderr.write(
+            f"::error::{REQUIREMENTS} does not pin mcp==, so the protocol version the "
+            "server negotiates is whatever resolves that day\n"
+        )
+        return 1
+
+    try:
+        from mcp.shared.version import SUPPORTED_PROTOCOL_VERSIONS as supported
+    except ImportError:
+        # Not a pass. Unreadable is a third outcome: reporting "supported" here
+        # would certify agreement this run never established.
+        print(
+            f"::notice::the mcp package is not importable here, so the {len(versions)} "
+            f"contract version(s) could not be checked against the pin ({pin}). "
+            f"UNVERIFIED on this run rather than confirmed."
+        )
+        return 0
+
+    missing = unsupported(versions, list(supported))
+    for version in missing:
+        sys.stderr.write(
+            f"::error::contracts/mcp/{version}/ freezes a protocol version that "
+            f"mcp=={pin} cannot speak (supports {', '.join(supported)}). The frozen "
+            f"surface describes a protocol the server will not negotiate.\n"
+        )
+    if missing:
+        return 1
+    print(
+        f"NFR-FLEX-14: every contract version ({', '.join(versions)}) is spoken by "
+        f"the pinned mcp=={pin}"
+    )
+    return 0
+
+
+if __name__ == "__main__":
+    sys.exit(main(sys.argv[1:]))

--- a/scripts/check-nfr-coverage.py
+++ b/scripts/check-nfr-coverage.py
@@ -101,12 +101,12 @@ import sys
 # that passes LESS is refused, because the only legitimate reason for the
 # number to fall is that an NFR genuinely stopped being checked -- and that is
 # what the coverage comparison already catches, loudly.
-COMMITTED_FLOOR = 14
+COMMITTED_FLOOR = 15
 
 # The unexplained count on the day it was first measured honestly. A ceiling
 # rather than a floor: this number must go DOWN, and a commit that raises it is
 # adding a requirement nobody accounted for.
-UNEXPLAINED_CEILING = 39
+UNEXPLAINED_CEILING = 38
 
 NFR_ID = re.compile(r"NFR-[A-Z]+-[A-Za-z0-9]+(?:-[A-Za-z0-9]+)*")
 MANIFESTO = "docs/architecture/manifesto/02-nfrs.md"

--- a/scripts/check-self-tests-are-bound.py
+++ b/scripts/check-self-tests-are-bound.py
@@ -47,6 +47,7 @@ SUBJECTS: dict[str, str] = {
     "check-contract-refs-are-local.py": "check_file",
     "check-gates-trigger-on-canon.py": "findings",
     "check-security-txt.py": "problems",
+    "check-mcp-protocol-version.py": "unsupported",
     # Added once the registry itself was measured against scripts/: these three
     # carried a --self-test and CI ran it, which proved the self-tests exist.
     # Nothing proved they would notice. Probed before registering -- stubbing


### PR DESCRIPTION
ci(nfr): arm NFR-FLEX-14 — the frozen MCP version must be one the pin can speak

contracts/mcp/2025-06-18/ freezes a protocol version by directory name. The
version OCU actually negotiates is not written in its code at all: it comes
from the `mcp` pin in requirements.txt, whose SUPPORTED_PROTOCOL_VERSIONS
decides what the server will accept. Nothing compared the two.

The failure is silent by construction. Bump the pin to a release that drops
2025-06-18 and the contract still parses, every schema gate stays green, and
the frozen surface describes a protocol the server cannot speak.

Measured: mcp==1.27.0 supports 2024-11-05, 2025-03-26, 2025-06-18 and
2025-11-25, so the contract is satisfiable today.

One near-miss worth recording. app.py:96 contains "protocolVersion":
"2024-11-05", which reads as a contradiction with the contract. It is a
documentation EXAMPLE of an initialize REQUEST inside an endpoint docstring,
not the version the server declares -- a grep-based check would have reported a
defect that does not exist. The library is the authority, so the checker reads
the library.

An unimportable mcp is reported as UNVERIFIED, not as agreement: certifying a
match this run never established is the failure mode #519 fixed elsewhere.

Probed on the real tree: renaming the contract directory to an unsupported
version exits 1, loosening the pin to `mcp>=1.0` exits 1, restoring exits 0,
and without the package the run notices rather than passing silently.

Coverage 14 -> 15, floor with it, ceiling 39 -> 38. Meta-gate 14 of 14 -- it
caught the missing --self-test step again.


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Quality Improvements**
  * Added an automated compatibility check to detect unsupported MCP protocol contract versions.
  * Compatibility validation now blocks releases when required protocol versions are unavailable.
  * Expanded automated self-test coverage for protocol compatibility scenarios.
  * Raised the minimum required non-functional requirement coverage threshold from 14 to 15.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->