### PR TITLE
fix(nfr-coverage): the manifesto has two row shapes and the parse assumed one

### DIFF
--- a/scripts/check-nfr-coverage.py
+++ b/scripts/check-nfr-coverage.py
@@ -106,7 +106,7 @@ COMMITTED_FLOOR = 15
 # The unexplained count on the day it was first measured honestly. A ceiling
 # rather than a floor: this number must go DOWN, and a commit that raises it is
 # adding a requirement nobody accounted for.
-UNEXPLAINED_CEILING = 38
+UNEXPLAINED_CEILING = 39
 
 NFR_ID = re.compile(r"NFR-[A-Z]+-[A-Za-z0-9]+(?:-[A-Za-z0-9]+)*")
 MANIFESTO = "docs/architecture/manifesto/02-nfrs.md"
@@ -295,11 +295,25 @@ def declared_rows(root: pathlib.Path) -> dict[str, str]:
         if not stripped.startswith("|"):
             continue
         cells = [c.strip() for c in stripped.split("|")]
-        if len(cells) > 5 and NFR_ID.fullmatch(cells[1]):
-            # Subject cell included: the completeness check excuses an id whose
-            # SUBJECT does not exist in the tree, and that word lives in cells[2]
-            # rather than in the verification column.
-            rows[cells[1]] = " ".join(cells[2:3] + cells[4:6])
+        if len(cells) > 4 and NFR_ID.fullmatch(cells[1]):
+            # The manifesto holds TWO row shapes, and a fixed index reads the
+            # wrong column for half of them. Measured: 101 rows are
+            # `ID | Scenario | Target | Verification | Source` and 89 insert a
+            # threat column -- `ID | Scenario | Threat | Target | Verification |
+            # Source`. Taking cells[4:6] for both swept the TARGET into the
+            # verification text on the wider rows, and three verdicts turned on
+            # it: NFR-SEC-30 counted as CI-checkable because its target says
+            # "edge integration test", not its verification.
+            #
+            # Subject is included deliberately -- the completeness check excuses
+            # an id whose SUBJECT is unbuilt, and that word lives in cells[2].
+            # Width 8 carries the threat column, width 7 does not. `>= 7` was
+            # wrong and measurably so: it matched BOTH shapes, moved 58 rows out
+            # of the CI-checkable set in one step, and the first two I read by
+            # hand -- NFR-COMP-01, NFR-COMP-11 -- had had their Source column
+            # read as their Verification.
+            verification = cells[5] if len(cells) >= 8 else cells[4]
+            rows[cells[1]] = " ".join([cells[2], verification])
     return rows
 
 


### PR DESCRIPTION
fix(nfr-coverage): the manifesto has two row shapes and the parse assumed one

Reading the remaining unexplained ids by hand, several showed a "target" of
"Spoofing" or "EoP, lateral" -- threats, not measurable values. The manifesto
carries two table shapes: 101 rows are
`ID | Scenario | Target | Verification | Source` and 89 insert a threat column
before Target. A fixed index reads a different column for each.

The parse took cells[4:6] for both, sweeping the TARGET into the verification
text on the wider rows. Three verdicts turned on it, and not in the safe
direction: NFR-SEC-30 counted as CI-checkable because its TARGET says "edge
integration test", while its verification says "fail-closed test".

One id returns to view: NFR-SEC-34, "continuous eval / red-team in CI",
verification "per-PR + nightly + per-release". The old parse read its Source
column and never saw the mechanism. Ceiling 38 -> 39 for that reason -- an id
the gate could not see, not a new gap.

My first fix was wrong and the probe caught it. Keying on `len(cells) >= 7`
matched BOTH shapes and moved 58 rows out of the CI-checkable set at once. A
58-row swing from a one-line change is not a result to accept: reading two of
them by hand -- NFR-COMP-01, NFR-COMP-11 -- showed their Source column being
read as Verification. The discriminator is width 8 versus width 7.

Coverage is unchanged at 15 of 190. What changed is that each row is now read
from its own verification column.


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Bug Fixes**
  * Improved compatibility when checking manifesto entries in different row formats.
  * Adjusted completeness checks to use the correct verification and subject fields.
  * Increased the allowed ceiling for unexplained CI-gated NFR items from 38 to 39.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->