### PR TITLE
ci(nfr-coverage): excuse the two adversarial-evaluation rows by mechanism

### DIFF
--- a/scripts/check-nfr-coverage.py
+++ b/scripts/check-nfr-coverage.py
@@ -106,7 +106,7 @@ COMMITTED_FLOOR = 15
 # The unexplained count on the day it was first measured honestly. A ceiling
 # rather than a floor: this number must go DOWN, and a commit that raises it is
 # adding a requirement nobody accounted for.
-UNEXPLAINED_CEILING = 39
+UNEXPLAINED_CEILING = 38
 
 NFR_ID = re.compile(r"NFR-[A-Z]+-[A-Za-z0-9]+(?:-[A-Za-z0-9]+)*")
 MANIFESTO = "docs/architecture/manifesto/02-nfrs.md"
@@ -365,7 +365,20 @@ def excused_ids(source: str) -> set[str]:
 # all present. Arming NFR-COMP-22 through that very pipeline (#527) is what
 # exposed it: a requirement cannot be both excused for want of a mechanism and
 # armed by that mechanism on the same day.
-ABSENT_MECHANISM = ("k6", "chaos test", "replay test", "per-template test")
+ABSENT_MECHANISM = (
+    "k6",
+    "chaos test",
+    "replay test",
+    "per-template test",
+    # Adversarial evaluation. NFR-SEC-34 asks for a red-team subset per PR and
+    # a full suite nightly; NFR-MAINT-12 for a threat-model re-run on
+    # DFD-bearing PRs. Measured across .github/, scripts/ and tests/: no
+    # promptfoo, garak, pyrit or threagile, and docs/architecture/threat-model/
+    # does not exist -- the only hits were path patterns in a docs-lint
+    # whitelist, which is a list of files that MAY exist, not a mechanism.
+    "per-pr + nightly",
+    "threat-model pass",
+)
 
 # The second reason an id cannot be armed: the SUBJECT does not exist. A
 # requirement about per-tenant isolation cannot have a check while nothing in
@@ -420,6 +433,8 @@ MECHANISM_PROBE = {
     "chaos test": "chaos",
     "replay test": "replay",
     "per-template test": "per-template",
+    "per-pr + nightly": "promptfoo",
+    "threat-model pass": "threagile",
 }
 
 


### PR DESCRIPTION
ci(nfr-coverage): excuse the two adversarial-evaluation rows by mechanism

NFR-SEC-34 returned to view when #533 fixed the column parse. It asks for a
10-minute red-team subset per PR and a full suite nightly. NFR-MAINT-12 asks
for a threat-model re-run on DFD-bearing PRs. Neither is armable, for the same
reason as k6 and chaos: the mechanism does not exist here.

Measured rather than assumed. No promptfoo, garak, pyrit or threagile anywhere
under .github/, scripts/ or tests/, and docs/architecture/threat-model/ does
not exist. The only hits for "threat-model" were path patterns in a docs-lint
whitelist -- a list of files that MAY exist, not a mechanism that runs. Reading
that as coverage would have been the comment-counted-as-invocation mistake in a
new costume.

Keyed to a probe rather than listed, so the exemption expires on its own.
Probed: dropping a file naming promptfoo into .github/workflows/ returns
NFR-SEC-34 to the unexplained set immediately; removing it takes it back out.

Ceiling 39 -> 38, and 37 exits 1. Coverage unchanged at 15 of 190 -- nothing
became more checked, one honest reason replaced two silent gaps.


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Bug Fixes**
  * Updated CI coverage checks to recognize adversarial-evaluation and threat-model validation mechanisms.
  * Added corresponding validation probes for prompt testing and threat modeling.
  * Reduced the allowed unexplained coverage ceiling from 39 to 38.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->