### PR TITLE
ci(release): run the synthetic transaction before the tag publishes (NFR-MAINT-05)

### DIFF
--- a/.github/workflows/nfr-gates.yml
+++ b/.github/workflows/nfr-gates.yml
@@ -125,6 +125,20 @@ jobs:
       - name: the shipped idle window is inside the NFR-SEC-40 bound
         run: python3 scripts/check-session-windows.py
 
+      - name: the release-synthetic checker itself discriminates
+        run: python3 scripts/check-release-synthetic.py --self-test
+
+      # NFR-MAINT-05 (synthetic transactions per deploy, "presence + success").
+      # The mechanism was present and unbound: build.yml stands a server up and
+      # drives /mcp against it, but it triggers on branches and pull requests,
+      # never on `push: tags`, so a tag published a release nothing had
+      # exercised. release.yml now runs the same live endpoint script and the
+      # publishing job needs it. The check walks the needs-graph instead of
+      # grepping for the word, because a grep passed on the unbound tree.
+      # Named here so the requirement counts as armed; this job blocks.
+      - name: no release publishes without a synthetic transaction
+        run: python3 scripts/check-release-synthetic.py
+
       - name: the MCP protocol checker itself discriminates
         run: python3 scripts/check-mcp-protocol-version.py --self-test
 
@@ -233,7 +247,7 @@ jobs:
         # unarmed remainder: that is the state of the layer, no single PR can
         # move it, and a gate nobody can turn green is a gate that gets ignored.
         # The number on every run is the point.
-        run: python3 scripts/check-nfr-coverage.py --min-armed 17
+        run: python3 scripts/check-nfr-coverage.py --min-armed 18
 
       - name: gate enforcement across the platform (report-only until protection is on)
         # The github context reaches the script through env, never by

--- a/.github/workflows/release.yml
+++ b/.github/workflows/release.yml
@@ -4,13 +4,78 @@ on:
   push:
     tags: ['v*']
 
+# Least privilege per job: only the publishing job writes. The synthetic job
+# reads the tree and talks to localhost.
 permissions:
-  contents: write
+  contents: read
 
 jobs:
+  synthetic:
+    name: Synthetic — POST /mcp against the tagged tree
+    runs-on: ubuntu-latest
+    permissions:
+      contents: read
+    # NFR-MAINT-05 asks for a synthetic transaction per deploy, "presence +
+    # success". The mechanism already existed in build.yml, but build.yml runs
+    # on branches and pull requests -- never on `push: tags`. So a tag published
+    # a release that nothing had driven. This job closes that: it stands the
+    # server up from the tagged tree and drives the same live endpoint script,
+    # and `release` needs it, so a failure here stops the publish.
+
+    steps:
+      - uses: actions/checkout@df4cb1c069e1874edd31b4311f1884172cec0e10  # v6.0.3
+        with:
+          # The job token stays in .git/config for every later step without this.
+          persist-credentials: false
+
+      - uses: docker/setup-buildx-action@d7f5e7f509e45cec5c76c4d5afdd7de93d0b3df5  # v4.1.0
+
+      - name: Build computer-use-server image locally
+        uses: docker/build-push-action@53b7df96c91f9c12dcc8a07bcb9ccacbed38856a  # v7.3.0
+        with:
+          context: ./computer-use-server
+          load: true
+          tags: cu-server:release-smoke
+          cache-from: type=gha,scope=server-smoke
+
+      - name: Start computer-use-server
+        run: |
+          # No real Docker socket needed: the orchestrator only has to boot,
+          # register MCP, and answer /health + /mcp. Sandbox container creation
+          # is exercised by build.yml's integration job, not here.
+          docker run -d --name cu-server -p 8081:8081 \
+            -e PUBLIC_BASE_URL=http://localhost:8081 \
+            -e BASE_DATA_DIR=/tmp/data \
+            cu-server:release-smoke
+
+      - name: Wait for /health
+        run: |
+          for i in $(seq 1 30); do
+            if curl -fsS http://localhost:8081/health >/dev/null 2>&1; then
+              echo ""; echo "healthy after ${i}s"; exit 0
+            fi
+            printf '.'
+            sleep 1
+          done
+          echo ""; echo "TIMEOUT — server never became healthy"
+          docker logs cu-server || true
+          exit 1
+
+      - name: Smoke /mcp endpoint
+        run: |
+          chmod +x tests/test-mcp-endpoint-live.sh
+          ./tests/test-mcp-endpoint-live.sh http://localhost:8081
+
+      - name: Dump server logs on failure
+        if: failure()
+        run: docker logs cu-server || true
+
   release:
     name: Create GitHub Release
+    needs: [synthetic]
     runs-on: ubuntu-latest
+    permissions:
+      contents: write
 
     steps:
       - uses: actions/checkout@df4cb1c069e1874edd31b4311f1884172cec0e10  # v6.0.3

--- a/scripts/check-nfr-coverage.py
+++ b/scripts/check-nfr-coverage.py
@@ -101,7 +101,7 @@ import sys
 # that passes LESS is refused, because the only legitimate reason for the
 # number to fall is that an NFR genuinely stopped being checked -- and that is
 # what the coverage comparison already catches, loudly.
-COMMITTED_FLOOR = 17
+COMMITTED_FLOOR = 18
 
 # The unexplained count on the day it was first measured honestly. A ceiling
 # rather than a floor: this number must go DOWN, and a commit that raises it is

--- a/scripts/check-release-synthetic.py
+++ b/scripts/check-release-synthetic.py
@@ -1,0 +1,260 @@
+#!/usr/bin/env python3
+# SPDX-License-Identifier: FSL-1.1-Apache-2.0
+# Copyright (c) 2025 Open Computer Use Contributors
+#
+# NFR-MAINT-05: a release runs a synthetic transaction before it publishes.
+#
+# The row asks for "presence + success", verified at the release-pipeline. Both
+# words matter and they fail differently. Presence is about the mechanism
+# existing; success is about a release being unable to proceed when it fails.
+#
+# The mechanism exists and is not shallow. build.yml stands a server up, waits
+# for health, and drives tests/test-mcp-endpoint-live.sh against the running
+# process; a second job spawns a real container over the runner's docker.sock.
+# That is a synthetic transaction by any reading.
+#
+# What was missing when this was written is the binding. release.yml triggers on
+# `push: tags: ['v*']` and its single job declares no `needs:`, so nothing that
+# exercises the artifact runs between the tag and the publish. The synthetic
+# transaction happens on pull requests, against a commit -- not against the
+# thing being shipped.
+#
+# So this check does not ask whether a smoke test is spelled anywhere. Grep
+# would already pass on today's tree and the requirement would still be unmet.
+# It asks whether the publishing job is REACHABLE without one: it walks the
+# `needs:` graph backwards from every job that publishes, and refuses when that
+# closure contains no job running a synthetic transaction.
+
+import re
+import sys
+from pathlib import Path
+
+WORKFLOWS = Path(".github/workflows")
+RELEASE = "release.yml"
+
+# Steps that put an artifact somewhere the world can pull it.
+#
+# docker/build-push-action is deliberately NOT here. The action builds and
+# publishes, and which one it does is decided by its inputs: `load: true` puts
+# the image in the local daemon and `push: true` sends it to a registry. Keying
+# on the action name called the release-gate job a publisher because it builds
+# an image to smoke-test, so `push: true` is the honest predicate.
+PUBLISHES = re.compile(
+    r"push:\s*true|softprops/action-gh-release|"
+    r"gh\s+release\s+create|helm\s+push|docker\s+push",
+    re.I,
+)
+# Steps that drive a running system rather than inspecting a file.
+#
+# Each alternative names an INVOCATION. Earlier versions matched `/mcp` and a
+# bare script name, which a hand-mutation showed passing on a workflow whose
+# steps had been gutted: `/mcp` survived inside a shell comment, and
+# `chmod +x tests/test-mcp-endpoint-live.sh` matched the script it only makes
+# executable. Both are mentions. A leading `./` or an interpreter, and a `curl`
+# that fails the build on a bad status, are the difference.
+SYNTHETIC = re.compile(
+    r"(?:\./|\bsh\s+|\bbash\s+)\S*test-mcp-endpoint-live|"
+    r"\bdocker\s+run\b|\bdocker\s+compose\s+up\b|"
+    r"\bcurl\s+[^\n]*\b(?:localhost|127\.0\.0\.1)\b",
+    re.I,
+)
+
+
+def jobs(text: str) -> dict[str, dict]:
+    """Job name -> {needs, body}. A hand parse: PyYAML is not a CI dependency here."""
+    lines = text.splitlines()
+    start = None
+    for index, line in enumerate(lines):
+        if re.match(r"^jobs:\s*$", line):
+            start = index + 1
+            break
+    if start is None:
+        return {}
+    found: dict[str, dict] = {}
+    current = None
+    for line in lines[start:]:
+        if line.strip() and not line.startswith(" "):
+            break  # a new top-level key ends the jobs block
+        header = re.match(r"^  ([A-Za-z0-9_-]+):\s*$", line)
+        if header:
+            current = header.group(1)
+            found[current] = {"needs": [], "body": []}
+            continue
+        if current:
+            found[current]["body"].append(line)
+            needs = re.match(r"^\s{4}needs:\s*(.+)$", line)
+            if needs:
+                raw = needs.group(1).strip()
+                found[current]["needs"] = re.findall(r"[A-Za-z0-9_-]+", raw)
+    return found
+
+
+def executable(body: list[str]) -> str:
+    """The lines a runner executes, dropping everything a human only reads.
+
+    Measured need: release.yml embeds `docker compose up` inside the release
+    notes as a quick-start instruction. Matching the whole job body read that
+    prose as a synthetic transaction and turned this check green on a tree where
+    nothing runs before the publish. A step is executable when it is a `run:`
+    command or a `uses:` action, so only those count.
+    """
+    out = []
+    depth = None
+    for line in body:
+        indent = len(line) - len(line.lstrip())
+        stripped = line.strip()
+        if not stripped:
+            continue
+        match = re.match(r"^-?\s*(run|uses):\s*(.*)$", stripped)
+        if match:
+            depth = indent
+            out.append(match.group(2))
+            continue
+        # Continuation lines of a block scalar belong to the step that opened it
+        # -- except shell comments, which a runner reads and does not execute. A
+        # mutation proved this matters: gutting every command left `/mcp` in a
+        # comment and the check stayed green.
+        if depth is not None and indent > depth:
+            if not stripped.startswith("#"):
+                out.append(stripped)
+            continue
+        depth = None
+    return "\n".join(out)
+
+
+def closure(name: str, graph: dict[str, dict]) -> set[str]:
+    """Every job that must succeed BEFORE `name` runs, excluding itself.
+
+    A job cannot vouch for itself: its own steps run alongside or after the
+    publish, so a smoke test sharing a job with `docker push` proves nothing
+    about ordering.
+    """
+    seen: set[str] = set()
+    stack = list(graph.get(name, {}).get("needs", []))
+    while stack:
+        item = stack.pop()
+        if item in seen or item not in graph:
+            continue
+        seen.add(item)
+        stack.extend(graph[item]["needs"])
+    return seen
+
+
+def unguarded_publishers(text: str) -> list[str]:
+    """Publishing jobs whose prerequisite closure runs no synthetic transaction."""
+    graph = jobs(text)
+    out = []
+    for name, job in sorted(graph.items()):
+        if not PUBLISHES.search(executable(job["body"])):
+            continue
+        reachable = closure(name, graph)
+        covered = any(SYNTHETIC.search(executable(graph[dep]["body"])) for dep in reachable)
+        if not covered:
+            where = ", ".join(sorted(reachable)) if reachable else "nothing — it declares no needs"
+            out.append(
+                f"{name}: publishes, but nothing it depends on ({where}) "
+                f"exercises a running system"
+            )
+    return out
+
+
+def self_test() -> int:
+    publish_step = "      - uses: docker/build-push-action@v6\n        with:\n          push: true\n"
+    bare = "on:\n  push:\n    tags: ['v*']\njobs:\n  release:\n    steps:\n" + publish_step
+    smoked = (
+        "on:\n  push:\n    tags: ['v*']\njobs:\n"
+        "  smoke:\n    steps:\n      - run: ./tests/test-mcp-endpoint-live.sh http://localhost:8081\n"
+        "  release:\n    needs: [smoke]\n    steps:\n" + publish_step
+    )
+    # The shape that made version two refuse a correct tree: a gate job builds
+    # an image to smoke-test it. Building is not publishing.
+    builds_locally = (
+        "jobs:\n  smoke:\n    steps:\n"
+        "      - uses: docker/build-push-action@v6\n        with:\n          load: true\n"
+        "      - run: docker run --rm x healthz\n"
+    )
+    detached = smoked.replace("    needs: [smoke]\n", "")
+    indirect = (
+        "jobs:\n"
+        "  smoke:\n    steps:\n      - run: docker run --rm x healthz\n"
+        "  gate:\n    needs: [smoke]\n    steps:\n      - run: echo ok\n"
+        "  release:\n    needs: [gate]\n    steps:\n      - run: gh release create v1\n"
+    )
+    nothing = "jobs:\n  lint:\n    steps:\n      - run: echo hi\n"
+    # The shape that made version one of this check pass on a tree where the
+    # requirement is unmet: the words appear in release-note prose, not in a step.
+    prose = (
+        "jobs:\n  release:\n    steps:\n"
+        "      - uses: softprops/action-gh-release@v2\n        with:\n          body: |\n"
+        "            ## Quick Start\n            ```bash\n            docker compose up\n            ```\n"
+    )
+    # A smoke test in the SAME job as the publish orders nothing.
+    same_job = (
+        "jobs:\n  release:\n    steps:\n"
+        "      - run: docker run --rm x healthz\n" + publish_step
+    )
+    # Every command gutted, but the words survive in a comment and a chmod.
+    # This is the mutation that caught version three.
+    mentioned = (
+        "jobs:\n  smoke:\n    steps:\n      - run: |\n"
+        "          # register MCP, and answer /health + /mcp\n"
+        "          chmod +x tests/test-mcp-endpoint-live.sh\n"
+        "          echo skipped\n"
+        "  release:\n    needs: [smoke]\n    steps:\n" + publish_step
+    )
+    cases = [
+        (bare, 1, "publishing with no synthetic transaction is refused"),
+        (prose, 1, "a smoke command quoted in release notes does not count"),
+        (same_job, 1, "a smoke step inside the publishing job does not count"),
+        (builds_locally, 0, "building an image with load: true is not publishing"),
+        (mentioned, 1, "a smoke script named in a comment or chmod is not a run"),
+        (smoked, 0, "a publisher that needs the smoke job passes"),
+        (detached, 1, "a smoke job present but not needed is refused"),
+        (indirect, 0, "coverage through a transitive need passes"),
+        (nothing, 0, "a workflow that publishes nothing has nothing to guard"),
+    ]
+    bad = 0
+    for text, want, label in cases:
+        got = 1 if unguarded_publishers(text) else 0
+        ok = got == want
+        bad += 0 if ok else 1
+        print(f"  {'ok' if ok else 'FAIL'}: {label}")
+    if bad:
+        print(f"self-test: {bad} case(s) failed")
+        return 1
+    print(f"self-test ok: {len(cases)} cases")
+    return 0
+
+
+def main(argv: list[str]) -> int:
+    if argv and argv[0] == "--self-test":
+        return self_test()
+    root = Path(argv[0]) if argv else Path(".")
+    path = root / WORKFLOWS / RELEASE
+    if not path.is_file():
+        sys.stderr.write(f"::error::{WORKFLOWS / RELEASE} is missing -- the check cannot judge\n")
+        return 2
+    text = path.read_text(encoding="utf-8")
+    if not jobs(text):
+        sys.stderr.write(
+            f"::error::no jobs parsed out of {RELEASE} -- the check would pass "
+            f"vacuously, so it refuses instead\n"
+        )
+        return 2
+    issues = unguarded_publishers(text)
+    for issue in issues:
+        sys.stderr.write(
+            f"::error::NFR-MAINT-05: {issue}. A tag would publish an artifact no "
+            f"synthetic transaction ever ran against.\n"
+        )
+    if issues:
+        return 1
+    print(
+        f"NFR-MAINT-05: every publishing job in {RELEASE} depends on a job that "
+        f"drives a running system"
+    )
+    return 0
+
+
+if __name__ == "__main__":
+    sys.exit(main(sys.argv[1:]))

--- a/scripts/check-self-tests-are-bound.py
+++ b/scripts/check-self-tests-are-bound.py
@@ -48,6 +48,7 @@ SUBJECTS: dict[str, str] = {
     "check-gates-trigger-on-canon.py": "findings",
     "check-security-txt.py": "problems",
     "check-mcp-protocol-version.py": "unsupported",
+    "check-release-synthetic.py": "unguarded_publishers",
     "check-session-windows.py": "problems",
     "check-guest-env-allowlist.py": "problems",
     # Added once the registry itself was measured against scripts/: these three


### PR DESCRIPTION
NFR-MAINT-05 asks for a synthetic transaction per deploy, "presence + success",
verified at the release pipeline. The mechanism was present and unbound.

`build.yml` stands the server up, waits for health, and drives
`tests/test-mcp-endpoint-live.sh` against the running process. It triggers on
branches and pull requests, never on `push: tags`. `release.yml` declared no
`needs:` at all, so a tag published a GitHub Release nothing had exercised.

## What changes

`release.yml` gains a `synthetic` job that builds the server from the tagged
tree, waits for `/health`, and runs the same live endpoint script. The
publishing job needs it, so a failure stops the publish. Permissions narrow per
job: only the publisher writes.

`check-release-synthetic.py` walks the `needs:` graph backwards from every
publishing job and refuses when that closure exercises no running system. A
grep would have passed on the unbound tree, which is why it is not one.

## The predicates were wrong four times

Each was caught by a hand-mutation that stayed green:

| Mutation | What passed | Fix |
|---|---|---|
| none — the tree as it stood | `docker compose up` in the release-notes body | only `run:`/`uses:` lines count |
| gut every command | `/mcp` surviving in a shell comment | comments in a block scalar dropped |
| downgrade the run | `chmod +x …live.sh` matched the script | pattern requires an invocation |
| — | a job vouching for itself | closure excludes the judged job |
| — | `build-push-action` with `load: true` read as publishing | `push: true` is the predicate |

Removing any one of the three drivers in the new job leaves it green — three
independent commands drive the live server. Removing all three reds it.

## Verification

- `--self-test`: 9 cases, including the two mention-not-invocation shapes.
- Live: red before the workflow change, green after.
- Mutation against the real `release.yml`: dropping `needs:`, deleting the
  synthetic job, and removing all three drivers each red; restore greens.
- Meta-gate 17 of 17 with the new checker registered.
- Coverage floor 17 -> 18.

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **New Features**
  * Added automated release checks that verify synthetic transactions run successfully before publishing.
  * Added health and endpoint validation during release verification, with diagnostic logs available when checks fail.

* **Bug Fixes**
  * Releases are now blocked when synthetic coverage is missing.
  * Increased the minimum required NFR coverage threshold from 17 to 18.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->