### PR TITLE
feat(nfr): compare the two contracts that state NFR-SEC-79's mandatory set

### DIFF
--- a/.github/workflows/nfr-gates.yml
+++ b/.github/workflows/nfr-gates.yml
@@ -131,6 +131,22 @@ jobs:
       - name: the browser-storage checker itself discriminates
         run: python3 scripts/check-browser-storage-clean.py --self-test
 
+      - name: the file-activity overlay checker itself discriminates
+        run: python3 scripts/check-file-activity-overlay.py --self-test
+
+      # NFR-SEC-79, the contract half. The chain-linkage half is not claimed:
+      # audit-fanin.asyncapi.yaml:230 says prev_hash/chain_hash are authored by
+      # the pipeline at ingest and are not part of the publish payload. What IS
+      # on the wire is the mandatory set, and two documents state it -- the
+      # AsyncAPI overlay named for this requirement, and FileActivityEvent in
+      # file-artifact-api.schema.json. Either can be relaxed alone without
+      # breaking anything else, so this compares them. The ocsf-class-identity
+      # gate covers a different statement (title vs vendored class) and passes
+      # on a relaxed overlay -- probed. Named here so the requirement counts as
+      # armed; this job blocks.
+      - name: a file-activity event still carries the NFR-SEC-79 mandatory set
+        run: python3 scripts/check-file-activity-overlay.py
+
       # NFR-SEC-82, the storage clause only. The row's embed-token half -- the
       # peer backend mints a short-TTL token and the UI verifies it before
       # setting session state -- belongs to the UI component, which is not in
@@ -262,7 +278,7 @@ jobs:
         # unarmed remainder: that is the state of the layer, no single PR can
         # move it, and a gate nobody can turn green is a gate that gets ignored.
         # The number on every run is the point.
-        run: python3 scripts/check-nfr-coverage.py --min-armed 19
+        run: python3 scripts/check-nfr-coverage.py --min-armed 20
 
       - name: gate enforcement across the platform (report-only until protection is on)
         # The github context reaches the script through env, never by

--- a/scripts/check-file-activity-overlay.py
+++ b/scripts/check-file-activity-overlay.py
@@ -1,0 +1,169 @@
+#!/usr/bin/env python3
+# SPDX-License-Identifier: FSL-1.1-Apache-2.0
+# Copyright (c) 2025 Open Computer Use Contributors
+#
+# NFR-SEC-79, the contract half: a file-activity audit event carries the OCU
+# mandatory set, and both contracts that state it agree.
+#
+# The row asks that every file operation on either storage surface commit a
+# chain-linked OCSF File System Activity event. The chain-linkage half is not
+# checkable here and deliberately not claimed: audit-fanin.asyncapi.yaml:230
+# says prev_hash/chain_hash are authored by the pipeline at ingest and are NOT
+# part of the publish payload. What a source must supply is the ordering input
+# and the mandatory fields, and that IS on the wire.
+#
+# Two documents state the same requirement and nothing compared them:
+#
+#   - audit-fanin.asyncapi.yaml carries an allOf overlay on the vendored OCSF
+#     class, named for NFR-SEC-79, making filesystem_id / intent / downloadable
+#     required on top of the base class.
+#   - file-artifact-api.schema.json defines FileActivityEvent with the same
+#     three in its own required list, and pins class_uid to const 1001.
+#
+# Either can be relaxed alone without breaking anything else. Drop `required`
+# from the overlay and the AsyncAPI still validates, the OCSF class file is
+# untouched, and the schema validator beside this one still passes -- while a
+# producer may now omit the disposition fields that decide whether a file left
+# the boundary. That is a silent loss of an audit property, which is the failure
+# this check exists to make loud.
+#
+# The existing ocsf-class-identity gate covers a different statement: that the
+# message title's class uid matches the vendored class file. It says nothing
+# about which fields are mandatory, so this does not duplicate it.
+
+import json
+import re
+import sys
+from pathlib import Path
+
+ASYNCAPI = Path("contracts/audit/audit-fanin.asyncapi.yaml")
+STORAGE = Path("contracts/storage/file-artifact-api.schema.json")
+DEFINITION = "FileActivityEvent"
+CLASS_UID = 1001
+
+# The disposition fields NFR-SEC-79 makes non-optional. Named rather than
+# derived from either document: deriving them from one would make this check
+# agree with whichever it read, which is the comparison failing open.
+MANDATORY = ("filesystem_id", "intent", "downloadable")
+
+
+def overlay_required(text: str) -> list[str] | None:
+    """The required list of the NFR-SEC-79 overlay, or None when it is gone.
+
+    Anchored on the overlay's own description rather than on a line number: the
+    file has several `required:` lines and the neighbouring messages carry their
+    own overlays.
+    """
+    marker = re.search(r"NFR-SEC-79 required-field overlay", text)
+    if not marker:
+        return None
+    tail = text[marker.end() :]
+    found = re.search(r"^\s*required:\s*\[([^\]]*)\]", tail, re.M)
+    if not found:
+        return None
+    return [item.strip() for item in found.group(1).split(",") if item.strip()]
+
+
+def storage_required(document: dict) -> list[str] | None:
+    """FileActivityEvent's required list from the storage schema."""
+    definition = document.get("$defs", {}).get(DEFINITION)
+    if not isinstance(definition, dict):
+        return None
+    required = definition.get("required")
+    return list(required) if isinstance(required, list) else None
+
+
+def storage_class_uid(document: dict) -> int | None:
+    """The class the storage schema pins FileActivityEvent to."""
+    definition = document.get("$defs", {}).get(DEFINITION, {})
+    if not isinstance(definition, dict):
+        return None
+    spec = definition.get("properties", {}).get("class_uid", {})
+    value = spec.get("const") if isinstance(spec, dict) else None
+    return value if isinstance(value, int) else None
+
+
+def problems(overlay: list[str] | None, storage: list[str] | None, uid: int | None) -> list[str]:
+    """Reasons to refuse. Empty means both contracts still carry the property."""
+    out = []
+    if overlay is None:
+        out.append(
+            f"the NFR-SEC-79 overlay is gone from {ASYNCAPI.name} -- a producer may "
+            f"omit the disposition fields and the contract still validates"
+        )
+    else:
+        missing = [f for f in MANDATORY if f not in overlay]
+        if missing:
+            out.append(f"{ASYNCAPI.name} overlay no longer requires {', '.join(missing)}")
+    if storage is None:
+        out.append(f"{STORAGE.name} no longer defines {DEFINITION} with a required list")
+    else:
+        missing = [f for f in MANDATORY if f not in storage]
+        if missing:
+            out.append(f"{STORAGE.name} {DEFINITION} no longer requires {', '.join(missing)}")
+    if uid is None:
+        out.append(f"{STORAGE.name} no longer pins {DEFINITION}.class_uid")
+    elif uid != CLASS_UID:
+        out.append(
+            f"{STORAGE.name} pins {DEFINITION}.class_uid to {uid}, not the OCSF "
+            f"File System Activity class {CLASS_UID}"
+        )
+    return out
+
+
+def self_test() -> int:
+    full = list(MANDATORY) + ["outcome"]
+    cases = [
+        ((full, full, CLASS_UID), 0, "both contracts carrying the set agree"),
+        ((None, full, CLASS_UID), 1, "a deleted overlay is refused"),
+        ((["filesystem_id"], full, CLASS_UID), 1, "an overlay missing two fields is refused"),
+        ((full, ["filesystem_id", "intent"], CLASS_UID), 1, "storage dropping downloadable is refused"),
+        ((full, None, CLASS_UID), 1, "a removed FileActivityEvent is refused"),
+        ((full, full, 1007), 1, "a class_uid repointed at another OCSF class is refused"),
+        ((full, full, None), 1, "an unpinned class_uid is refused"),
+    ]
+    bad = 0
+    for (overlay, storage, uid), want, label in cases:
+        got = 1 if problems(overlay, storage, uid) else 0
+        ok = got == want
+        bad += 0 if ok else 1
+        print(f"  {'ok' if ok else 'FAIL'}: {label}")
+    if bad:
+        print(f"self-test: {bad} case(s) failed")
+        return 1
+    print(f"self-test ok: {len(cases)} cases")
+    return 0
+
+
+def main(argv: list[str]) -> int:
+    if argv and argv[0] == "--self-test":
+        return self_test()
+    root = Path(argv[0]) if argv else Path(".")
+    for path in (ASYNCAPI, STORAGE):
+        if not (root / path).is_file():
+            sys.stderr.write(f"::error::{path} is missing -- the check cannot judge\n")
+            return 2
+    try:
+        document = json.loads((root / STORAGE).read_text(encoding="utf-8"))
+    except json.JSONDecodeError as exc:
+        sys.stderr.write(f"::error::{STORAGE} is not readable JSON ({exc}) -- refusing\n")
+        return 2
+
+    overlay = overlay_required((root / ASYNCAPI).read_text(encoding="utf-8"))
+    storage = storage_required(document)
+    uid = storage_class_uid(document)
+
+    issues = problems(overlay, storage, uid)
+    for issue in issues:
+        sys.stderr.write(f"::error::NFR-SEC-79: {issue}\n")
+    if issues:
+        return 1
+    print(
+        f"NFR-SEC-79 (contract half): both contracts require "
+        f"{', '.join(MANDATORY)} on a File System Activity ({CLASS_UID}) event"
+    )
+    return 0
+
+
+if __name__ == "__main__":
+    sys.exit(main(sys.argv[1:]))

--- a/scripts/check-nfr-coverage.py
+++ b/scripts/check-nfr-coverage.py
@@ -101,12 +101,12 @@ import sys
 # that passes LESS is refused, because the only legitimate reason for the
 # number to fall is that an NFR genuinely stopped being checked -- and that is
 # what the coverage comparison already catches, loudly.
-COMMITTED_FLOOR = 19
+COMMITTED_FLOOR = 20
 
 # The unexplained count on the day it was first measured honestly. A ceiling
 # rather than a floor: this number must go DOWN, and a commit that raises it is
 # adding a requirement nobody accounted for.
-UNEXPLAINED_CEILING = 31
+UNEXPLAINED_CEILING = 30
 
 NFR_ID = re.compile(r"NFR-[A-Z]+-[A-Za-z0-9]+(?:-[A-Za-z0-9]+)*")
 MANIFESTO = "docs/architecture/manifesto/02-nfrs.md"

--- a/scripts/check-self-tests-are-bound.py
+++ b/scripts/check-self-tests-are-bound.py
@@ -50,6 +50,7 @@ SUBJECTS: dict[str, str] = {
     "check-mcp-protocol-version.py": "unsupported",
     "check-release-synthetic.py": "unguarded_publishers",
     "check-browser-storage-clean.py": "leaks",
+    "check-file-activity-overlay.py": "problems",
     "check-session-windows.py": "problems",
     "check-guest-env-allowlist.py": "problems",
     # Added once the registry itself was measured against scripts/: these three


### PR DESCRIPTION
NFR-SEC-79 asks that every file operation on either storage surface commit a
chain-linked OCSF File System Activity event.

**The chain-linkage half is not claimed here.** `audit-fanin.asyncapi.yaml:230`
says `prev_hash`/`chain_hash` are authored by the pipeline at ingest and are not
part of the publish payload. What a source must supply is the mandatory set, and
that is on the wire.

## Two statements, never compared

| Document | What it says |
|---|---|
| `audit-fanin.asyncapi.yaml` | an `allOf` overlay named for NFR-SEC-79 makes `filesystem_id` / `intent` / `downloadable` required on the vendored OCSF class |
| `file-artifact-api.schema.json` | `FileActivityEvent` requires the same three and pins `class_uid` to `const 1001` |

Either can be relaxed alone without breaking anything else. Drop `required` from
the overlay and the AsyncAPI still validates, the vendored class is untouched,
and the schema validator stays green — while a producer may now omit the
disposition fields that decide whether a file left the boundary.

## Not a duplicate of the existing gate

Checked rather than assumed: relaxing the overlay and running
`check-ocsf-class-identity.py` **exits 0**. That gate compares a message title to
the vendored class file and says nothing about which fields are mandatory.

`MANDATORY` is named in the checker rather than derived from either document —
deriving it would make the check agree with whichever file it read, which is the
comparison failing open.

## Verification

Probed against the real contracts:

| Mutation | Result |
|---|---|
| overlay drops `intent` + `downloadable` | red |
| overlay marker deleted | red |
| storage drops `downloadable` | red |
| `class_uid` repointed to 1007 | red |
| restore | green |

Coverage 19 -> 20 of 190; unexplained ceiling 31 -> 30. Meta-gate 19 of 19.

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Tests**
  * Added automated validation for file activity event contracts, including required fields and class identifiers.
  * Added self-tests covering valid, invalid, missing, and malformed contract files.
  * Added enforcement to ensure the new validation is bound to its self-test.

* **Chores**
  * Updated non-functional requirement coverage thresholds to reflect the expanded security validation.
  * CI checks now enforce the file activity contract and revised coverage standards.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->