### PR TITLE
feat(nfr): require every arm to be declared, not acquired by a mention

### DIFF
--- a/.github/workflows/nfr-gates.yml
+++ b/.github/workflows/nfr-gates.yml
@@ -140,6 +140,20 @@ jobs:
       - name: the operator-body checker itself discriminates
         run: python3 scripts/check-operator-bodies-hint-only.py --self-test
 
+      - name: the arms-ledger checker itself discriminates
+        run: python3 scripts/check-arms-are-declared.py --self-test
+
+      # The coverage scanner attributes an arm to any file that NAMES an id.
+      # That is right for finding assertions and silent about the inverse: a
+      # comment citing an id arms it with nothing behind the name. It happened --
+      # a checker header cited a second requirement as context and coverage rose
+      # by two, caught only because the expected rise was one. This holds a
+      # hand-written ledger of which checker answers for which id, and refuses
+      # an id counted but undeclared, a declared id no longer counted, and a
+      # ledger row naming a file that does not exist.
+      - name: every armed requirement is declared, not acquired by a mention
+        run: python3 scripts/check-arms-are-declared.py
+
       # NFR-SEC-26 (contract half). The operator surface establishes identity out
       # of band -- operatorPeerCred, from the peer credential of the host-owned
       # 0700 socket -- and the file states the consequence: bodies carry HINTS,

--- a/scripts/check-arms-are-declared.py
+++ b/scripts/check-arms-are-declared.py
@@ -1,0 +1,156 @@
+#!/usr/bin/env python3
+# SPDX-License-Identifier: FSL-1.1-Apache-2.0
+# Copyright (c) 2025 Open Computer Use Contributors
+#
+# An arm must be declared, not acquired by mentioning an id.
+#
+# check-nfr-coverage.py attributes an arm to any file under scripts/, .github/
+# or tests/ that NAMES an NFR id. That is the right rule for finding assertions
+# -- a check has to name what it checks -- but it is silent about the inverse:
+# writing an id into a comment arms it, with no assertion behind the name.
+#
+# It happened. A checker header cited a second requirement alongside the one it
+# holds, purely as context, and coverage jumped by two. The number was noticed
+# only because the expected rise was one; a wider gap, or a less attentive
+# reading, and the ledger would have carried a requirement nothing checks.
+#
+# So this gate holds a ledger. Every armed id is listed here with the checker
+# that answers for it, and the gate refuses three ways:
+#
+#   - an id counted as armed but absent from the ledger (a mention acquired it)
+#   - an id in the ledger no longer counted (its assertion left the tree)
+#   - a ledger entry naming a checker that does not exist
+#
+# The ledger is written by hand on purpose. Deriving it from the scan would make
+# it agree with whatever the scan found, which is exactly the failure it exists
+# to catch. Adding a row here is the step where somebody states, deliberately,
+# that a check now answers for a requirement.
+
+import importlib.util
+import pathlib
+import sys
+
+COVERAGE = pathlib.Path("scripts/check-nfr-coverage.py")
+
+# id -> the file carrying the assertion. Where an id is named by several files
+# (a workflow step plus its script), the SCRIPT is named: it is the thing that
+# would have to change for the assertion to stop holding.
+LEDGER: dict[str, str] = {
+    "NFR-COMP-17": "scripts/check-compliance-front-matter.py",
+    "NFR-COMP-19": "scripts/check-compliance-front-matter.py",
+    "NFR-COMP-22": ".github/workflows/gate3-rehearsal.yml",
+    "NFR-COMP-27": "scripts/check-soar-revoke-frozen.py",
+    "NFR-FLEX-01": "scripts/check-no-vendor-sdk.py",
+    "NFR-FLEX-13": "scripts/check-contract-refs-are-local.py",
+    "NFR-FLEX-14": "scripts/check-mcp-protocol-version.py",
+    "NFR-MAINT-05": "scripts/check-release-synthetic.py",
+    "NFR-MAINT-AUDIT-SCHEMA": "scripts/check-audit-fanin-inv1.py",
+    "NFR-SEC-07": "scripts/check-schemas-are-closed.py",
+    "NFR-SEC-15": "tests/test-docker-image.sh",
+    "NFR-SEC-18": "scripts/check-pin-policy.py",
+    "NFR-SEC-19": "scripts/check-pin-policy.py",
+    "NFR-SEC-26": "scripts/check-operator-bodies-hint-only.py",
+    "NFR-SEC-40": "scripts/check-session-windows.py",
+    "NFR-SEC-51": "scripts/check-schemas-are-closed.py",
+    "NFR-SEC-75": "scripts/check-guest-env-allowlist.py",
+    "NFR-SEC-79": "scripts/check-file-activity-overlay.py",
+    "NFR-SEC-82": "scripts/check-browser-storage-clean.py",
+    "NFR-SEC-87": "scripts/check-schemas-are-closed.py",
+    "NFR-SEC-88": "scripts/check-ocsf-class-identity.py",
+    "NFR-SEC-89": "scripts/check-gates-are-required.py",
+}
+
+
+def _coverage_module(root: pathlib.Path):
+    """Import the coverage checker so both read one definition of 'armed'."""
+    path = root / COVERAGE
+    spec = importlib.util.spec_from_file_location("coverage_check", path)
+    if spec is None or spec.loader is None:
+        return None
+    module = importlib.util.module_from_spec(spec)
+    spec.loader.exec_module(module)
+    return module
+
+
+def counted_arms(root: pathlib.Path) -> set[str] | None:
+    """Ids the coverage scanner counts as armed, or None when it cannot run."""
+    module = _coverage_module(root)
+    if module is None:
+        return None
+    return set(module.armed_ids(root, module.declared_ids(root)))
+
+
+def problems(counted: set[str], ledger: dict[str, str], root: pathlib.Path) -> list[str]:
+    """Reasons to refuse. Empty means the ledger and the scan agree."""
+    out = []
+    for identifier in sorted(counted - set(ledger)):
+        out.append(
+            f"{identifier} counts as armed but is not in the ledger -- if a comment "
+            f"acquired it, remove the mention; if a check now answers for it, add "
+            f"the row deliberately"
+        )
+    for identifier in sorted(set(ledger) - counted):
+        out.append(
+            f"{identifier} is in the ledger but no longer counts as armed -- its "
+            f"assertion left the tree"
+        )
+    for identifier, holder in sorted(ledger.items()):
+        if not (root / holder).is_file():
+            out.append(f"{identifier} names {holder}, which does not exist")
+    return out
+
+
+def self_test() -> int:
+    here = pathlib.Path(".")
+    ledger = {"NFR-A-1": "scripts/check-nfr-coverage.py"}
+    cases = [
+        (({"NFR-A-1"}, ledger), 0, "ledger and scan agreeing pass"),
+        (({"NFR-A-1", "NFR-B-2"}, ledger), 1, "an id armed by a mention is refused"),
+        ((set(), ledger), 1, "a ledger entry that stopped being armed is refused"),
+        (({"NFR-A-1"}, {"NFR-A-1": "scripts/does-not-exist.py"}), 1, "a missing holder is refused"),
+    ]
+    bad = 0
+    for (counted, entries), want, label in cases:
+        got = 1 if problems(counted, entries, here) else 0
+        ok = got == want
+        bad += 0 if ok else 1
+        print(f"  {'ok' if ok else 'FAIL'}: {label}")
+    if bad:
+        print(f"self-test: {bad} case(s) failed")
+        return 1
+    print(f"self-test ok: {len(cases)} cases")
+    return 0
+
+
+def main(argv: list[str]) -> int:
+    if argv and argv[0] == "--self-test":
+        return self_test()
+    root = pathlib.Path(argv[0]) if argv else pathlib.Path(".")
+    if not (root / COVERAGE).is_file():
+        sys.stderr.write(f"::error::{COVERAGE} is missing -- the ledger cannot be compared\n")
+        return 2
+    counted = counted_arms(root)
+    if counted is None:
+        sys.stderr.write(
+            f"::error::{COVERAGE} could not be imported -- refusing rather than "
+            f"reporting agreement this run never established\n"
+        )
+        return 2
+    if not counted:
+        sys.stderr.write(
+            f"::error::the coverage scan counted zero arms -- the ledger would "
+            f"look wrong for a reason that is not the ledger's\n"
+        )
+        return 2
+
+    issues = problems(counted, LEDGER, root)
+    for issue in issues:
+        sys.stderr.write(f"::error::arms-ledger: {issue}\n")
+    if issues:
+        return 1
+    print(f"arms-ledger: {len(LEDGER)} declared arm(s), each counted and each with a holder")
+    return 0
+
+
+if __name__ == "__main__":
+    sys.exit(main(sys.argv[1:]))

--- a/scripts/check-nfr-coverage.py
+++ b/scripts/check-nfr-coverage.py
@@ -249,6 +249,13 @@ def armed_ids(root: pathlib.Path, ids: set[str]) -> dict[str, list[str]]:
     """
     hits: dict[str, list[str]] = {}
     this_file = pathlib.Path(__file__).resolve()
+    # The arms ledger is a REGISTER of arms, not a source of them. It lists every
+    # armed id by name, so counting it would let a hand-written row arm a
+    # requirement nothing checks -- and the ledger gate would agree, since both
+    # sides would be reading the same file. Measured before excluding it: adding
+    # NFR-SEC-33 to the ledger raised coverage from 22 to 23 and the ledger gate
+    # still exited 0.
+    ledger_file = (root / "scripts" / "check-arms-are-declared.py").resolve()
     for directory in CODE_DIRS:
         base = root / directory
         if not base.is_dir():
@@ -261,7 +268,8 @@ def armed_ids(root: pathlib.Path, ids: set[str]) -> dict[str, list[str]]:
             # armed -- by itself. Measured: coverage read 3 of 187 with the two
             # fixtures counted, 1 of 187 without. A gate that satisfies its own
             # assertion is the failure mode this whole file exists to name.
-            if path.resolve() == this_file:
+            resolved = path.resolve()
+            if resolved == this_file or resolved == ledger_file:
                 continue
             # Build artifacts are not checks. A .pyc keeps the NFR ids of the
             # source it was compiled from, so a deleted checker stays "armed"

--- a/scripts/check-self-tests-are-bound.py
+++ b/scripts/check-self-tests-are-bound.py
@@ -53,6 +53,7 @@ SUBJECTS: dict[str, str] = {
     "check-file-activity-overlay.py": "problems",
     "check-soar-revoke-frozen.py": "problems",
     "check-operator-bodies-hint-only.py": "problems",
+    "check-arms-are-declared.py": "problems",
     "check-session-windows.py": "problems",
     "check-guest-env-allowlist.py": "problems",
     # Added once the registry itself was measured against scripts/: these three


### PR DESCRIPTION
The coverage scanner attributes an arm to any file under `scripts/`, `.github/`
or `tests/` that **names** an NFR id. That is the right rule for finding
assertions — a check has to name what it checks — and it is silent about the
inverse: writing an id into a comment arms it, with no assertion behind the name.

## It already happened

While wiring NFR-SEC-26, the checker header cited a second requirement alongside
the one it holds, purely as context, and coverage rose by **two**. Caught only
because the expected rise was one. A wider gap, or a less careful reading, and
the count would have carried a requirement nothing checks.

## The gate

A hand-written ledger of which checker answers for which id. It refuses three
ways:

- an id counted as armed but **undeclared** (a mention acquired it)
- a **declared** id no longer counted (its assertion left the tree)
- a ledger row naming a file that does not exist

Hand-written on purpose: deriving it from the scan would make it agree with
whatever the scan found, which is the failure it exists to catch.

## Building it introduced the same failure one level up

The ledger names all 22 ids, so the scanner counted **the ledger itself** as
their arm:

| | armed | ledger gate |
|---|---|---|
| add `NFR-SEC-33` as a ledger row, before the fix | 22 -> **23** | exit 0 — agrees, both sides read one file |
| same row, after excluding the ledger from the scan | stays **22** | exit 1 — "in the ledger but no longer counts as armed" |

`armed_ids()` now excludes the ledger the way it already excludes the coverage
checker's own fixtures.

## Verification

Red-probed with the exact historical failure: reintroducing the `NFR-SEC-43`
mention in the SEC-26 checker header reds with *"counts as armed but is not in
the ledger"*.

Coverage stays **22 of 190** — this adds no arm, it makes the existing ones
answerable. Meta-gate 22 of 22.

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

- **New Features**
  - Added automated validation to ensure all tracked requirements are explicitly declared and linked to existing files.
  - Added consistency checks between declared requirements and coverage results.
  - Added self-tests and clear error handling for missing or invalid coverage data.

- **Bug Fixes**
  - Prevented the validation tool itself from being incorrectly counted as a covered requirement.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->