### PR TITLE
fix(nfr): excuse NFR-SEC-52 by the operator surface this tree does not deploy

### DIFF
--- a/scripts/check-nfr-coverage.py
+++ b/scripts/check-nfr-coverage.py
@@ -121,7 +121,7 @@ COMMITTED_FLOOR = 23
 # there and invisible. A ceiling that only ever falls would have locked the
 # blind spot in permanently -- the honest move is to raise it once, say why, and
 # resume the ratchet from the wider number.
-UNEXPLAINED_CEILING = 45
+UNEXPLAINED_CEILING = 44
 
 NFR_ID = re.compile(r"NFR-[A-Z]+-[A-Za-z0-9]+(?:-[A-Za-z0-9]+)*")
 MANIFESTO = "docs/architecture/manifesto/02-nfrs.md"
@@ -496,6 +496,21 @@ ABSENT_SUBJECT = (
     # There the storage leg is one leg of a single forward-proxy egress, and its
     # subject -- proxy, egress -- is present in this tree. It stays unexcused.
     "ocu-filestore",
+    # NFR-SEC-52 asks for a rendered-manifest check that the agent-facing MCP
+    # gateway has no network route to the operator/Control-API ingress. The
+    # assertion needs two deployed surfaces to hold apart, and this tree
+    # deploys one. Probed across the server, the chart, the compose files and
+    # the image: operator-ingress, kill-switch, killswitch, denylist and
+    # "mcp gateway" all return nothing. The contracts DESCRIBE the operator
+    # surface -- operator-rest.openapi.yaml is detailed about it -- but no chart
+    # template or compose service renders it, and the single `operator` hit in
+    # helm/ is the word in a comment about human operators.
+    #
+    # Keyed on `kill-switch` rather than `operator-ingress`: both are absent
+    # today, but the kill-switch is the capability whose reachability the row is
+    # actually about, so the exemption expires when the dangerous surface
+    # appears rather than when someone renames an ingress.
+    "kill-switch",
     # NFR-SEC-84 asks for a CSRF token on state-mutating requests, after an
     # embed-token-verified browser session (NFR-SEC-82). No browser credential
     # exists here: probed for set_cookie / request.cookies / Set-Cookie in


### PR DESCRIPTION
NFR-SEC-52 asks for a rendered-manifest check that the agent-facing MCP gateway
has **no network route** to the operator/Control-API ingress — the kill-switch,
denylist and lifecycle surface.

The assertion needs two deployed surfaces to hold apart. This tree deploys one.

## Measured

| Probe | Result |
|---|---|
| `operator-ingress`, `kill-switch`, `killswitch`, `denylist`, `mcp gateway` | all absent |
| `operator` under `helm/` | one hit — the word in a comment about *human* operators |

The contracts **describe** the operator surface — `operator-rest.openapi.yaml` is
detailed about it, and NFR-SEC-26 is armed against that description — but no
chart template or compose service renders it.

## Keyed on `kill-switch`, not `operator-ingress`

Both are absent today, but the kill-switch is the *capability* whose reachability
the row is about. The exemption should expire when the dangerous surface appears,
not when somebody renames an ingress.

Probed: planting a template that mentions a kill-switch puts NFR-SEC-52 straight
back into the unexplained set.

## What this defers

The row prescribes the gate's shape — a required context whose self-test plants
the violation it claims to catch. Worth building the day the operator ingress
renders; claiming it before then would assert a separation between surfaces that
do not both exist.

Unexplained ceiling 45 -> 44. Coverage unchanged at 23 of 190.

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Chores**
  * Updated coverage validation thresholds.
  * Documented the current exception for the unavailable kill-switch capability.
  * Improved tracking of absent capabilities in compliance checks.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->