### PR TITLE
feat(nfr): refuse a mutating route that is not scoped to a session

### DIFF
--- a/.github/workflows/nfr-gates.yml
+++ b/.github/workflows/nfr-gates.yml
@@ -146,6 +146,20 @@ jobs:
       - name: the phone-home checker itself discriminates
         run: python3 scripts/check-no-phone-home.py --self-test
 
+      - name: the mutating-console checker itself discriminates
+        run: python3 scripts/check-no-mutating-console.py --self-test
+
+      # NFR-IC-02 (no mutating operator-console UI in v1; CLAUDE.md locks the
+      # same thing as a non-goal). The distinction is SCOPE, not the verb. This
+      # server serves mutating routes and a page that calls them -- restart the
+      # container, kill a process -- and every one is keyed on chat_id, with the
+      # page supplying exactly one from window.__CONFIG__. That is a data-plane
+      # session panel, which the row routes to NFR-SEC-82 instead. An operator
+      # console is the other shape: a mutating route with no session in its
+      # path. Named here so the requirement counts as armed; this job blocks.
+      - name: every mutating route is session-scoped and no console ships
+        run: python3 scripts/check-no-mutating-console.py
+
       # NFR-SEC-16 (zero vendor-controlled outbound in the default config,
       # verified by CI artifact inspection of installer + runtime). Two
       # distinctions decide what this refuses, both measured: a link is not a
@@ -338,7 +352,7 @@ jobs:
         # unarmed remainder: that is the state of the layer, no single PR can
         # move it, and a gate nobody can turn green is a gate that gets ignored.
         # The number on every run is the point.
-        run: python3 scripts/check-nfr-coverage.py --min-armed 23
+        run: python3 scripts/check-nfr-coverage.py --min-armed 24
 
       - name: gate enforcement across the platform (report-only until protection is on)
         # The github context reaches the script through env, never by

--- a/scripts/check-arms-are-declared.py
+++ b/scripts/check-arms-are-declared.py
@@ -43,6 +43,7 @@ LEDGER: dict[str, str] = {
     "NFR-FLEX-01": "scripts/check-no-vendor-sdk.py",
     "NFR-FLEX-13": "scripts/check-contract-refs-are-local.py",
     "NFR-FLEX-14": "scripts/check-mcp-protocol-version.py",
+    "NFR-IC-02": "scripts/check-no-mutating-console.py",
     "NFR-MAINT-05": "scripts/check-release-synthetic.py",
     "NFR-MAINT-AUDIT-SCHEMA": "scripts/check-audit-fanin-inv1.py",
     "NFR-SEC-07": "scripts/check-schemas-are-closed.py",

--- a/scripts/check-nfr-coverage.py
+++ b/scripts/check-nfr-coverage.py
@@ -101,7 +101,7 @@ import sys
 # that passes LESS is refused, because the only legitimate reason for the
 # number to fall is that an NFR genuinely stopped being checked -- and that is
 # what the coverage comparison already catches, loudly.
-COMMITTED_FLOOR = 23
+COMMITTED_FLOOR = 24
 
 # The unexplained count on the day it was first measured honestly. A ceiling
 # rather than a floor: this number must go DOWN, and a commit that raises it is
@@ -121,7 +121,7 @@ COMMITTED_FLOOR = 23
 # there and invisible. A ceiling that only ever falls would have locked the
 # blind spot in permanently -- the honest move is to raise it once, say why, and
 # resume the ratchet from the wider number.
-UNEXPLAINED_CEILING = 44
+UNEXPLAINED_CEILING = 43
 
 NFR_ID = re.compile(r"NFR-[A-Z]+-[A-Za-z0-9]+(?:-[A-Za-z0-9]+)*")
 MANIFESTO = "docs/architecture/manifesto/02-nfrs.md"

--- a/scripts/check-no-mutating-console.py
+++ b/scripts/check-no-mutating-console.py
@@ -1,0 +1,152 @@
+#!/usr/bin/env python3
+# SPDX-License-Identifier: FSL-1.1-Apache-2.0
+# Copyright (c) 2025 Open Computer Use Contributors
+#
+# NFR-IC-02: no mutating operator-console surface ships.
+#
+# The row says every state-mutating operator / control-plane action goes through
+# the CLI and declarative config, with no mutating operator-console UI in v1.
+# CLAUDE.md states the same thing as a locked non-goal: v1 ships zero admin UI,
+# because every UI is new attack surface, auth burden and accessibility cost.
+#
+# The distinction that makes this checkable is SCOPE, not the HTTP verb. This
+# server does serve mutating routes and a page that calls them -- restart the
+# container, kill a process, stop ttyd. Reading them shows every one is keyed on
+# `chat_id` and the page supplies exactly one, from window.__CONFIG__, so the UI
+# acts on the session it belongs to and cannot address another. That is a
+# data-plane surface, which the row explicitly routes to NFR-SEC-82 instead.
+#
+# An operator console is the other shape: a mutating route with no session in
+# its path, reachable by whoever loads the page, acting on somebody else's
+# session or on the deployment. That is what this refuses.
+#
+# So the check is: every mutating route the server declares carries a session
+# parameter in its path. A route that mutates without one is either an operator
+# action -- which belongs in the CLI -- or a data-plane action that has lost its
+# scope, and both are worth stopping.
+
+import re
+import sys
+from pathlib import Path
+
+APP = Path("computer-use-server/app.py")
+STATIC = Path("computer-use-server/static")
+
+# Mutating HTTP verbs as FastAPI decorators.
+ROUTE = re.compile(r"^@app\.(post|put|patch|delete)\(\s*[\"']([^\"']+)[\"']", re.M)
+# The path parameter that scopes an action to one session.
+SESSION_PARAM = re.compile(r"\{chat_id[^}]*\}")
+
+# Names that would make a page an operator console rather than a session panel.
+CONSOLE_MARKERS = ("ocu-admin", "admin-console", "operator-console", "admin_ui")
+
+
+def mutating_routes(source: str) -> list[tuple[str, str]]:
+    """(verb, path) for every mutating route the app declares."""
+    return [(verb.upper(), path) for verb, path in ROUTE.findall(source)]
+
+
+def unscoped(routes: list[tuple[str, str]]) -> list[str]:
+    """Mutating routes with no session in their path."""
+    return [f"{verb} {path}" for verb, path in routes if not SESSION_PARAM.search(path)]
+
+
+def console_assets(assets: dict[str, str]) -> list[str]:
+    """Served files that identify themselves as an operator console."""
+    out = []
+    for name, text in sorted(assets.items()):
+        lowered = text.lower()
+        for marker in CONSOLE_MARKERS:
+            if marker in lowered:
+                out.append(f"{name} names {marker}")
+    return out
+
+
+def problems(routes: list[tuple[str, str]], assets: dict[str, str]) -> list[str]:
+    """Reasons to refuse. Empty means no mutating operator surface ships."""
+    out = []
+    for route in unscoped(routes):
+        out.append(
+            f"{route} mutates without a session in its path -- an operator action "
+            f"belongs in the CLI, and a data-plane action without a scope can "
+            f"address somebody else's session"
+        )
+    out.extend(console_assets(assets))
+    return out
+
+
+def self_test() -> int:
+    session = [("POST", "/terminal/{chat_id}/restart-container")]
+    cases = [
+        ((session, {}), 0, "a mutating route scoped to a session passes"),
+        ((session + [("POST", "/admin/kill-all")], {}), 1, "an unscoped mutating route is refused"),
+        (([("DELETE", "/sessions/{id}")], {}), 1, "a session param by another name is not the scope"),
+        ((session, {"p.js": "fetch('/api/x')"}), 0, "a session panel is not a console"),
+        ((session, {"a.js": "mount('#ocu-admin-root')"}), 1, "an asset naming ocu-admin is refused"),
+        (([], {}), 0, "no mutating route at all passes"),
+    ]
+    bad = 0
+    for (routes, assets), want, label in cases:
+        got = 1 if problems(routes, assets) else 0
+        ok = got == want
+        bad += 0 if ok else 1
+        print(f"  {'ok' if ok else 'FAIL'}: {label}")
+
+    # The extractor, on constructed source. Without this the parse is untested:
+    # on the shipped tree every route is scoped, so a stub returning [] passes.
+    found = mutating_routes(
+        '@app.post("/terminal/{chat_id}/x")\n@app.get("/read")\n@app.delete("/admin/y")\n'
+    )
+    if found != [("POST", "/terminal/{chat_id}/x"), ("DELETE", "/admin/y")]:
+        bad += 1
+        sys.stderr.write(f"self-test FAIL: extractor returned {found}\n")
+    else:
+        print("  ok: mutating verbs are extracted and GET is not one")
+
+    if bad:
+        print(f"self-test: {bad} case(s) failed")
+        return 1
+    print("self-test ok: 7 cases")
+    return 0
+
+
+def main(argv: list[str]) -> int:
+    if argv and argv[0] == "--self-test":
+        return self_test()
+    root = Path(argv[0]) if argv else Path(".")
+    path = root / APP
+    if not path.is_file():
+        sys.stderr.write(f"::error::{APP} is missing -- the check cannot judge\n")
+        return 2
+    source = path.read_text(encoding="utf-8")
+    routes = mutating_routes(source)
+    if not routes:
+        # Not a pass. This server declares mutating routes; finding none means
+        # the decorator shape changed and the check stopped reading the surface.
+        sys.stderr.write(
+            f"::error::no mutating route parsed out of {APP} -- the route shape "
+            f"changed and this check would pass without inspecting one\n"
+        )
+        return 2
+
+    assets = {}
+    base = root / STATIC
+    if base.is_dir():
+        for asset in sorted(base.rglob("*")):
+            if asset.is_file() and asset.suffix.lower() in (".js", ".html") and not asset.name.endswith(".min.js"):
+                assets[str(asset.relative_to(root))] = asset.read_text(encoding="utf-8", errors="ignore")
+
+    issues = problems(routes, assets)
+    for issue in issues:
+        sys.stderr.write(f"::error::NFR-IC-02: {issue}\n")
+    if issues:
+        return 1
+    print(
+        f"NFR-IC-02: all {len(routes)} mutating route(s) are session-scoped and "
+        f"none of {len(assets)} served asset(s) is an operator console"
+    )
+    return 0
+
+
+if __name__ == "__main__":
+    sys.exit(main(sys.argv[1:]))

--- a/scripts/check-self-tests-are-bound.py
+++ b/scripts/check-self-tests-are-bound.py
@@ -55,6 +55,7 @@ SUBJECTS: dict[str, str] = {
     "check-operator-bodies-hint-only.py": "problems",
     "check-arms-are-declared.py": "problems",
     "check-no-phone-home.py": "problems",
+    "check-no-mutating-console.py": "problems",
     "check-session-windows.py": "problems",
     "check-guest-env-allowlist.py": "problems",
     # Added once the registry itself was measured against scripts/: these three


### PR DESCRIPTION
NFR-IC-02 says every state-mutating operator / control-plane action goes through the CLI and declarative config, with **no mutating operator-console UI in v1**. `CLAUDE.md` locks the same thing as a non-goal.

## The distinction is scope, not the verb

This server *does* serve six mutating routes, and a page that calls five of them — restart the container, resurrect it, stop ttyd, kill a process. Reading the call sites is what settles it: every mutating route is keyed on `{chat_id}`, and the page supplies exactly one, from `window.__CONFIG__`.

So the UI acts on the session it belongs to and cannot address another. That is a **data-plane** surface, which the row explicitly routes to NFR-SEC-82 instead.

An operator console is the other shape — a mutating route with **no session in its path**, acting on somebody else's session or on the deployment. That is what this refuses, along with a served asset identifying itself as one.

An empty route list exits **2** rather than passing: this server declares mutating routes, so parsing none means the decorator shape changed and the check stopped reading the surface it claims to inspect.

## Verification

| Mutation | Result |
|---|---|
| plant `POST /admin/kill-all-sessions` | red |
| strip `{chat_id}` off an existing route | red |
| add an `ocu-admin` marker to a served asset | red |
| restore | green |

One self-test fixture was wrong on the first run — `const OCU_ADMIN = 1`, an underscore where the marker is hyphenated — so the case failed for its own spelling rather than the logic. Fixed to a realistic `'#ocu-admin-root'` mount.

Coverage 23 -> 24 of 190; unexplained ceiling 44 -> 43. Meta-gate 24 of 24.

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **New Features**
  * Added automated checks to ensure mutating routes are tied to chat sessions.
  * Added validation to detect operator-console markers in served assets.
  * Added self-tests and blocking enforcement for these safeguards.

* **Tests**
  * Bound the new checker to the self-test verification process.
  * Increased the minimum required NFR coverage from 23 to 24.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->