### PR TITLE
feat(nfr): keep `docker compose up` working with no configuration

### DIFF
--- a/.github/workflows/nfr-gates.yml
+++ b/.github/workflows/nfr-gates.yml
@@ -149,6 +149,21 @@ jobs:
       - name: the mutating-console checker itself discriminates
         run: python3 scripts/check-no-mutating-console.py --self-test
 
+      - name: the one-click compose checker itself discriminates
+        run: python3 scripts/check-one-click-compose.py --self-test
+
+      # NFR-FLEX-07b, the Compose half ("one-click solo install preserves
+      # Compose path"). The smoke test already exists in build.yml; what was
+      # unguarded is the property that makes the install one-click at all --
+      # every interpolated variable carries a default. Adding ${OCU_LICENSE_KEY}
+      # to a service is a one-line edit that leaves every gate green and the
+      # smoke test passing, because the test supplies its own environment; the
+      # person it breaks is the solo installer on a clean checkout. The
+      # documented-endpoint-list half is NOT claimed -- no enumerable list
+      # exists. Named here so the requirement counts as armed; this job blocks.
+      - name: docker compose up still needs no configuration
+        run: python3 scripts/check-one-click-compose.py
+
       # NFR-IC-02 (no mutating operator-console UI in v1; CLAUDE.md locks the
       # same thing as a non-goal). The distinction is SCOPE, not the verb. This
       # server serves mutating routes and a page that calls them -- restart the
@@ -352,7 +367,7 @@ jobs:
         # unarmed remainder: that is the state of the layer, no single PR can
         # move it, and a gate nobody can turn green is a gate that gets ignored.
         # The number on every run is the point.
-        run: python3 scripts/check-nfr-coverage.py --min-armed 24
+        run: python3 scripts/check-nfr-coverage.py --min-armed 25
 
       - name: gate enforcement across the platform (report-only until protection is on)
         # The github context reaches the script through env, never by

--- a/scripts/check-arms-are-declared.py
+++ b/scripts/check-arms-are-declared.py
@@ -41,6 +41,7 @@ LEDGER: dict[str, str] = {
     "NFR-COMP-22": ".github/workflows/gate3-rehearsal.yml",
     "NFR-COMP-27": "scripts/check-soar-revoke-frozen.py",
     "NFR-FLEX-01": "scripts/check-no-vendor-sdk.py",
+    "NFR-FLEX-07b": "scripts/check-one-click-compose.py",
     "NFR-FLEX-13": "scripts/check-contract-refs-are-local.py",
     "NFR-FLEX-14": "scripts/check-mcp-protocol-version.py",
     "NFR-IC-02": "scripts/check-no-mutating-console.py",

--- a/scripts/check-nfr-coverage.py
+++ b/scripts/check-nfr-coverage.py
@@ -101,7 +101,7 @@ import sys
 # that passes LESS is refused, because the only legitimate reason for the
 # number to fall is that an NFR genuinely stopped being checked -- and that is
 # what the coverage comparison already catches, loudly.
-COMMITTED_FLOOR = 24
+COMMITTED_FLOOR = 25
 
 # The unexplained count on the day it was first measured honestly. A ceiling
 # rather than a floor: this number must go DOWN, and a commit that raises it is
@@ -121,7 +121,7 @@ COMMITTED_FLOOR = 24
 # there and invisible. A ceiling that only ever falls would have locked the
 # blind spot in permanently -- the honest move is to raise it once, say why, and
 # resume the ratchet from the wider number.
-UNEXPLAINED_CEILING = 40
+UNEXPLAINED_CEILING = 39
 
 NFR_ID = re.compile(r"NFR-[A-Z]+-[A-Za-z0-9]+(?:-[A-Za-z0-9]+)*")
 MANIFESTO = "docs/architecture/manifesto/02-nfrs.md"

--- a/scripts/check-one-click-compose.py
+++ b/scripts/check-one-click-compose.py
@@ -1,0 +1,145 @@
+#!/usr/bin/env python3
+# SPDX-License-Identifier: FSL-1.1-Apache-2.0
+# Copyright (c) 2025 Open Computer Use Contributors
+#
+# NFR-FLEX-07b, the Compose half: `docker compose up` still works with no
+# configuration.
+#
+# The row's target is "one-click solo install preserves Compose path", verified
+# by a Compose smoke test. The smoke test exists -- build.yml stands the stack
+# up from docker-compose.test.yml and drives it -- so what is unguarded is the
+# property that makes the install one-click in the first place: every variable
+# the compose file interpolates carries a default.
+#
+# That is the invariant a well-meaning change breaks quietly. Adding
+# `${OCU_LICENSE_KEY}` to a service is a one-line edit that leaves every gate
+# green, the file valid, and the smoke test passing -- the test supplies its own
+# environment. The person it breaks is the solo installer running `docker
+# compose up` on a clean checkout, who gets an empty value substituted and a
+# failure somewhere downstream.
+#
+# Measured when this was written: 25 variables interpolated across the file, 25
+# of them with a `:-` default, and no `required: true` anywhere. So the property
+# holds and this keeps it holding.
+#
+# The one-click claim is a standing invariant for the solo audience, not a
+# nice-to-have, which is why it is worth a gate rather than a comment.
+
+import re
+import sys
+from pathlib import Path
+
+COMPOSE = Path("docker-compose.yml")
+
+# ${VAR}, ${VAR:-default}, ${VAR-default}. The middle form is the one that keeps
+# the install one-click; the bare form is what this refuses.
+INTERPOLATION = re.compile(r"\$\{([A-Za-z_][A-Za-z0-9_]*)([:-][^}]*)?\}")
+
+
+def variables(text: str) -> dict[str, bool]:
+    """Every interpolated variable -> whether it carries a default."""
+    found: dict[str, bool] = {}
+    for name, suffix in INTERPOLATION.findall(text):
+        has_default = bool(suffix)
+        # A variable used twice counts as defaulted only if EVERY use defaults
+        # it: one bare use is enough to break a clean checkout.
+        found[name] = found.get(name, True) and has_default
+    return found
+
+
+def services(text: str) -> list[str]:
+    """Service names, so an empty parse can be told from an empty file."""
+    block = re.search(r"^services:\s*$", text, re.M)
+    if not block:
+        return []
+    return re.findall(r"^  ([a-z][a-z0-9_-]*):\s*$", text[block.end() :], re.M)
+
+
+def problems(found: dict[str, bool], text: str) -> list[str]:
+    """Reasons to refuse. Empty means `docker compose up` needs no config."""
+    out = []
+    for name in sorted(n for n, defaulted in found.items() if not defaulted):
+        out.append(
+            f"${{{name}}} is interpolated with no default -- a clean checkout "
+            f"running `docker compose up` substitutes an empty value"
+        )
+    for match in re.finditer(r"required:\s*true", text):
+        line = text[: match.start()].count("\n") + 1
+        out.append(
+            f"line {line} marks a variable required -- the one-click path cannot "
+            f"demand configuration"
+        )
+    return out
+
+
+def self_test() -> int:
+    cases = [
+        (({"PORT": True, "IMAGE": True}, ""), 0, "every variable defaulted passes"),
+        (({"PORT": True, "LICENSE": False}, ""), 1, "a bare interpolation is refused"),
+        (({}, "  environment:\n    - X:\n        required: true\n"), 1,
+         "a required variable is refused"),
+        (({}, ""), 0, "a file interpolating nothing passes"),
+    ]
+    bad = 0
+    for (found, text), want, label in cases:
+        got = 1 if problems(found, text) else 0
+        ok = got == want
+        bad += 0 if ok else 1
+        print(f"  {'ok' if ok else 'FAIL'}: {label}")
+
+    # The extractor, on constructed text. On the shipped file every variable is
+    # defaulted, so a stub returning {} would pass unnoticed.
+    found = variables("a: ${ONE:-x}\nb: ${TWO}\nc: ${ONE:-y}\n")
+    if found != {"ONE": True, "TWO": False}:
+        bad += 1
+        sys.stderr.write(f"self-test FAIL: extractor returned {found}\n")
+    else:
+        print("  ok: a bare use is extracted and a defaulted one is not")
+
+    # A variable used both ways is NOT safe: the bare use breaks the install.
+    mixed = variables("a: ${DUAL:-x}\nb: ${DUAL}\n")
+    if mixed != {"DUAL": False}:
+        bad += 1
+        sys.stderr.write(f"self-test FAIL: mixed use returned {mixed}\n")
+    else:
+        print("  ok: one bare use outweighs a defaulted one")
+
+    if bad:
+        print(f"self-test: {bad} case(s) failed")
+        return 1
+    print("self-test ok: 6 cases")
+    return 0
+
+
+def main(argv: list[str]) -> int:
+    if argv and argv[0] == "--self-test":
+        return self_test()
+    root = Path(argv[0]) if argv else Path(".")
+    path = root / COMPOSE
+    if not path.is_file():
+        sys.stderr.write(f"::error::{COMPOSE} is missing -- the one-click path is gone\n")
+        return 2
+    text = path.read_text(encoding="utf-8")
+    found = services(text)
+    if not found:
+        sys.stderr.write(
+            f"::error::no service parsed out of {COMPOSE} -- the file shape changed "
+            f"and this check would pass without reading the install path\n"
+        )
+        return 2
+
+    issues = problems(variables(text), text)
+    for issue in issues:
+        sys.stderr.write(f"::error::NFR-FLEX-07b: {issue}\n")
+    if issues:
+        return 1
+    print(
+        f"NFR-FLEX-07b: {len(found)} compose service(s), "
+        f"{len(variables(text))} interpolated variable(s), every one defaulted -- "
+        f"`docker compose up` needs no configuration"
+    )
+    return 0
+
+
+if __name__ == "__main__":
+    sys.exit(main(sys.argv[1:]))

--- a/scripts/check-self-tests-are-bound.py
+++ b/scripts/check-self-tests-are-bound.py
@@ -56,6 +56,7 @@ SUBJECTS: dict[str, str] = {
     "check-arms-are-declared.py": "problems",
     "check-no-phone-home.py": "problems",
     "check-no-mutating-console.py": "problems",
+    "check-one-click-compose.py": "problems",
     "check-session-windows.py": "problems",
     "check-guest-env-allowlist.py": "problems",
     # Added once the registry itself was measured against scripts/: these three


### PR DESCRIPTION
NFR-FLEX-07b's target is *"one-click solo install preserves Compose path"*,
verified by a Compose smoke test. The smoke test **exists** — `build.yml` stands
the stack up from `docker-compose.test.yml` and drives it. What was unguarded is
the property that makes the install one-click at all: every interpolated variable
carries a default.

## The failure this catches is quiet

Adding `${OCU_LICENSE_KEY}` to a service is a one-line edit that leaves the file
valid, every gate green, and **the smoke test passing** — the test supplies its
own environment. The person it breaks is the solo installer running
`docker compose up` on a clean checkout, who gets an empty value substituted and
a failure somewhere downstream.

Measured: **25** variables interpolated, **25** with a `:-` default, no
`required: true` anywhere, five services.

A variable used both ways counts as **undefaulted** — one bare use is enough to
break a clean checkout, so `${DUAL:-x}` elsewhere does not rescue `${DUAL}`.

## What is not claimed

The row also asks for ≤ 5 documented run-time egress endpoints per release. No
enumerable list exists — every hit for "egress endpoint" or "endpoint list"
outside the research buffer is prose about bounded contexts and abstractions, not
a list a check could count. That half stays unclaimed.

## Verification

| Mutation | Result |
|---|---|
| strip the default off `MCP_PORT` | red |
| add a bare `${OCU_LICENSE_KEY}` | red |
| mark something `required: true` | red |
| restore | green |
| unparseable service list | **exit 2**, not a pass |

Coverage 24 -> 25 of 190; unexplained ceiling 40 -> 39. Meta-gate 25 of 25.

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **New Features**
  * Added validation for Docker Compose configurations used in one-click installation.
  * Detects missing variable defaults, invalid required-variable declarations, missing files, and malformed configurations.
  * Added self-test support for the new validation.

* **Bug Fixes**
  * Strengthened release checks by requiring at least 25 covered requirements and enforcing the updated coverage limits.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->