### PR TITLE
fix(nfr): excuse NFR-SEC-77 by the microVM tier that is post-v1

### DIFF
--- a/scripts/check-nfr-coverage.py
+++ b/scripts/check-nfr-coverage.py
@@ -121,7 +121,7 @@ COMMITTED_FLOOR = 25
 # there and invisible. A ceiling that only ever falls would have locked the
 # blind spot in permanently -- the honest move is to raise it once, say why, and
 # resume the ratchet from the wider number.
-UNEXPLAINED_CEILING = 39
+UNEXPLAINED_CEILING = 38
 
 NFR_ID = re.compile(r"NFR-[A-Z]+-[A-Za-z0-9]+(?:-[A-Za-z0-9]+)*")
 MANIFESTO = "docs/architecture/manifesto/02-nfrs.md"
@@ -540,6 +540,18 @@ ABSENT_SUBJECT = (
     # enumerated transitions in NFR-SEC-72's row, so it swept away a
     # requirement already recorded as a live gap (#551).
     "provisioning",
+    # NFR-SEC-77 is explicitly gated on the microVM tier: death of the in-guest
+    # supervisor forces guest death via kernel.panic=1 and panic-on-oops, so no
+    # headless guest outlives its supervisor holding a live egress. That tier is
+    # post-v1 (#161) and nothing here sets a guest kernel cmdline: kernel.panic,
+    # panic-on-oops, panic_on_oops and "in-guest supervisor" all return nothing.
+    #
+    # `pid-1` DOES return present, and the hits are the cgroup-v2 PID-1
+    # evacuation shim in the dind init -- a docker-in-docker workaround, not a
+    # guest supervisor. Keyed on `kernel.panic`, which appears in exactly one
+    # row. The broader `microvm tier` would also sweep NFR-FLEX-02 and
+    # NFR-FLEX-06, where the tier is one item in a list rather than the subject.
+    "kernel.panic",
     # NFR-SEC-84 asks for a CSRF token on state-mutating requests, after an
     # embed-token-verified browser session (NFR-SEC-82). No browser credential
     # exists here: probed for set_cookie / request.cookies / Set-Cookie in


### PR DESCRIPTION
NFR-SEC-77 is gated on the microVM tier **in its own row**: death of the in-guest
supervisor forces guest death via `kernel.panic=1` and panic-on-oops, so no
headless guest outlives its supervisor while holding a live egress.

That tier is post-v1 (#161), and nothing here sets a guest kernel cmdline —
`kernel.panic`, `panic-on-oops`, `panic_on_oops` and "in-guest supervisor" all
return nothing.

## `pid-1` is present and is not this

The hits are the cgroup-v2 PID-1 evacuation shim in the dind init — a
docker-in-docker workaround for `docker-library/docker#308`, not a guest
supervisor. Keying on it would rest the exemption on an unrelated mechanism.

## Keyed on `kernel.panic`

It appears in exactly one row. The broader `microvm tier` would also sweep
NFR-FLEX-02 and NFR-FLEX-06, where the tier is one item in a substrate list
rather than the subject — both stay in the unexplained set, verified.

## Verification

Planting a template that mentions `kernel.panic` puts NFR-SEC-77 straight back,
so the exemption expires when the tier lands.

Unexplained ceiling 39 -> 38. Coverage unchanged at 25 of 190.

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

- **Chores**
  - Updated release validation rules to account for a documented exception related to supervisor failure propagation.
  - Refined coverage checks so the tracked exception is excluded from unrelated process and microVM references.
  - Adjusted the validation threshold to reflect the updated coverage baseline.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->