### PR TITLE
feat(nfr): keep the admission pairing matrix a complete product

### DIFF
--- a/.github/workflows/nfr-gates.yml
+++ b/.github/workflows/nfr-gates.yml
@@ -152,6 +152,20 @@ jobs:
       - name: the one-click compose checker itself discriminates
         run: python3 scripts/check-one-click-compose.py --self-test
 
+      - name: the admission-matrix checker itself discriminates
+        run: python3 scripts/check-admission-matrix-complete.py --self-test
+
+      # NFR-SEC-38 (contract half): the 9-cell profile x tier pairing matrix in
+      # contracts/admission/runtime-tokens.schema.json stays complete. Deleting
+      # one allOf branch leaves the schema valid -- measured with the pinned
+      # ajv-cli@5.0.0 the json-schema gate runs, which exits 0 on it -- while
+      # the pair that branch covered becomes unvalidated at admission. The axes
+      # are derived FROM the schema and the cartesian product required, so this
+      # does not restate the contract and drift from it. Named here so the
+      # requirement counts as armed; this job blocks.
+      - name: the admission pairing matrix is a complete product
+        run: python3 scripts/check-admission-matrix-complete.py
+
       # NFR-FLEX-07b, the Compose half ("one-click solo install preserves
       # Compose path"). The smoke test already exists in build.yml; what was
       # unguarded is the property that makes the install one-click at all --
@@ -367,7 +381,7 @@ jobs:
         # unarmed remainder: that is the state of the layer, no single PR can
         # move it, and a gate nobody can turn green is a gate that gets ignored.
         # The number on every run is the point.
-        run: python3 scripts/check-nfr-coverage.py --min-armed 25
+        run: python3 scripts/check-nfr-coverage.py --min-armed 26
 
       - name: gate enforcement across the platform (report-only until protection is on)
         # The github context reaches the script through env, never by

--- a/scripts/check-admission-matrix-complete.py
+++ b/scripts/check-admission-matrix-complete.py
@@ -1,0 +1,162 @@
+#!/usr/bin/env python3
+# SPDX-License-Identifier: FSL-1.1-Apache-2.0
+# Copyright (c) 2025 Open Computer Use Contributors
+#
+# NFR-SEC-38, the contract half: the admission pairing matrix stays complete.
+#
+# The row asks for admission-time validation of a declared workload-trust
+# profile against the configured runtime tier, using a 9-cell pairing matrix.
+# contracts/admission/runtime-tokens.schema.json carries that matrix as nine
+# `allOf` branches, one per (profile, tier) pair, over a closed profile enum.
+#
+# Nothing guarded it. Deleting a branch leaves the schema valid JSON Schema, the
+# contracts-lint json-schema gate green, and the declaration file still
+# conforming -- while the pair that branch covered is no longer required to
+# appear. A deployment could then declare a matrix that says nothing about, say,
+# (untrusted, runc), and admission would have no rule to apply for the most
+# dangerous cell in the table.
+#
+# The completeness property is what makes a pairing matrix a matrix rather than
+# a list of examples, so it is checked as a cartesian product: every profile in
+# the closed enum, crossed with every tier the matrix mentions, must have a
+# branch. Enumerating the expected pairs in this file instead would restate the
+# contract and drift from it; deriving the axes FROM the schema and requiring
+# the product keeps one source of truth while still refusing a missing cell.
+#
+# The subject probe does not see this file -- contracts/ is outside SUBJECT_DIRS
+# -- so `workload_trust_profile` reads as absent to the coverage scanner. It is
+# not: the profile enum and the matrix both live here. Excusing the row would
+# have been wrong, which is why this arms it instead.
+
+import json
+import sys
+from itertools import product
+from pathlib import Path
+
+SCHEMA = Path("contracts/admission/runtime-tokens.schema.json")
+PROFILE_DEF = "WorkloadTrustProfile"
+
+
+def _cells(document: dict) -> list[tuple[str, str]]:
+    """(profile, tier) for every branch the matrix requires."""
+    matrix = document.get("properties", {}).get("matrix", {})
+    out = []
+    for branch in matrix.get("allOf", []):
+        properties = branch.get("contains", {}).get("properties", {})
+        profile = properties.get("profile", {}).get("const")
+        tier = properties.get("tier", {}).get("const")
+        if profile and tier:
+            out.append((profile, tier))
+    return out
+
+
+def _profiles(document: dict) -> list[str]:
+    """The closed profile enum, from its definition."""
+    definition = document.get("$defs", {}).get(PROFILE_DEF, {})
+    values = definition.get("enum")
+    return sorted(values) if isinstance(values, list) else []
+
+
+def missing_cells(profiles: list[str], cells: list[tuple[str, str]]) -> list[str]:
+    """Pairs the matrix does not require. Empty means the product is covered."""
+    if not profiles or not cells:
+        return []
+    tiers = sorted({tier for _, tier in cells})
+    have = set(cells)
+    return [f"({p}, {t})" for p, t in product(sorted(profiles), tiers) if (p, t) not in have]
+
+
+def problems(document: dict) -> list[str]:
+    """Reasons to refuse. Empty means the matrix is a complete product."""
+    profiles = _profiles(document)
+    cells = _cells(document)
+    out = []
+    if not profiles:
+        out.append(f"$defs.{PROFILE_DEF} no longer declares a closed enum of profiles")
+    if not cells:
+        out.append(
+            "the matrix declares no (profile, tier) branch -- admission has no "
+            "pairing rule to validate against"
+        )
+    if profiles and cells:
+        tiers = sorted({tier for _, tier in cells})
+        expected = len(profiles) * len(tiers)
+        for pair in missing_cells(profiles, cells):
+            out.append(
+                f"the matrix requires no branch for {pair} -- that pairing would be "
+                f"unvalidated at admission"
+            )
+        if len(cells) != len(set(cells)):
+            out.append("the matrix declares a duplicate (profile, tier) branch")
+        if not out and len(cells) != expected:
+            out.append(f"the matrix has {len(cells)} branches, expected {expected}")
+    return out
+
+
+def self_test() -> int:
+    def doc(profiles, cells):
+        return {
+            "$defs": {PROFILE_DEF: {"enum": profiles}},
+            "properties": {
+                "matrix": {
+                    "allOf": [
+                        {"contains": {"properties": {"profile": {"const": p}, "tier": {"const": t}}}}
+                        for p, t in cells
+                    ]
+                }
+            },
+        }
+
+    full = [(p, t) for p in ("a", "b") for t in ("x", "y")]
+    cases = [
+        (doc(["a", "b"], full), 0, "a complete product passes"),
+        (doc(["a", "b"], full[:-1]), 1, "one deleted cell is refused"),
+        (doc(["a", "b", "c"], full), 1, "a profile with no cells is refused"),
+        (doc([], full), 1, "a removed profile enum is refused"),
+        (doc(["a", "b"], []), 1, "an empty matrix is refused"),
+        (doc(["a", "b"], full + [("a", "x")]), 1, "a duplicate branch is refused"),
+    ]
+    bad = 0
+    for document, want, label in cases:
+        got = 1 if problems(document) else 0
+        ok = got == want
+        bad += 0 if ok else 1
+        print(f"  {'ok' if ok else 'FAIL'}: {label}")
+    if bad:
+        print(f"self-test: {bad} case(s) failed")
+        return 1
+    print(f"self-test ok: {len(cases)} cases")
+    return 0
+
+
+def main(argv: list[str]) -> int:
+    if argv and argv[0] == "--self-test":
+        return self_test()
+    root = Path(argv[0]) if argv else Path(".")
+    path = root / SCHEMA
+    if not path.is_file():
+        sys.stderr.write(f"::error::{SCHEMA} is missing -- the check cannot judge\n")
+        return 2
+    try:
+        document = json.loads(path.read_text(encoding="utf-8"))
+    except json.JSONDecodeError as exc:
+        sys.stderr.write(f"::error::{SCHEMA} is not readable JSON ({exc}) -- refusing\n")
+        return 2
+
+    issues = problems(document)
+    for issue in issues:
+        sys.stderr.write(f"::error::NFR-SEC-38: {issue}\n")
+    if issues:
+        return 1
+    profiles = _profiles(document)
+    cells = _cells(document)
+    tiers = sorted({tier for _, tier in cells})
+    print(
+        f"NFR-SEC-38: the admission matrix requires all {len(cells)} cells of "
+        f"{len(profiles)} profile(s) x {len(tiers)} tier(s)"
+    )
+    return 0
+
+
+if __name__ == "__main__":
+    sys.exit(main(sys.argv[1:]))

--- a/scripts/check-arms-are-declared.py
+++ b/scripts/check-arms-are-declared.py
@@ -53,6 +53,7 @@ LEDGER: dict[str, str] = {
     "NFR-SEC-18": "scripts/check-pin-policy.py",
     "NFR-SEC-19": "scripts/check-pin-policy.py",
     "NFR-SEC-26": "scripts/check-operator-bodies-hint-only.py",
+    "NFR-SEC-38": "scripts/check-admission-matrix-complete.py",
     "NFR-SEC-40": "scripts/check-session-windows.py",
     "NFR-SEC-51": "scripts/check-schemas-are-closed.py",
     "NFR-SEC-75": "scripts/check-guest-env-allowlist.py",

--- a/scripts/check-nfr-coverage.py
+++ b/scripts/check-nfr-coverage.py
@@ -101,7 +101,7 @@ import sys
 # that passes LESS is refused, because the only legitimate reason for the
 # number to fall is that an NFR genuinely stopped being checked -- and that is
 # what the coverage comparison already catches, loudly.
-COMMITTED_FLOOR = 25
+COMMITTED_FLOOR = 26
 
 # The unexplained count on the day it was first measured honestly. A ceiling
 # rather than a floor: this number must go DOWN, and a commit that raises it is
@@ -121,7 +121,7 @@ COMMITTED_FLOOR = 25
 # there and invisible. A ceiling that only ever falls would have locked the
 # blind spot in permanently -- the honest move is to raise it once, say why, and
 # resume the ratchet from the wider number.
-UNEXPLAINED_CEILING = 38
+UNEXPLAINED_CEILING = 37
 
 NFR_ID = re.compile(r"NFR-[A-Z]+-[A-Za-z0-9]+(?:-[A-Za-z0-9]+)*")
 MANIFESTO = "docs/architecture/manifesto/02-nfrs.md"

--- a/scripts/check-self-tests-are-bound.py
+++ b/scripts/check-self-tests-are-bound.py
@@ -57,6 +57,7 @@ SUBJECTS: dict[str, str] = {
     "check-no-phone-home.py": "problems",
     "check-no-mutating-console.py": "problems",
     "check-one-click-compose.py": "problems",
+    "check-admission-matrix-complete.py": "problems",
     "check-session-windows.py": "problems",
     "check-guest-env-allowlist.py": "problems",
     # Added once the registry itself was measured against scripts/: these three


### PR DESCRIPTION
NFR-SEC-38 asks for admission-time validation of a declared workload-trust profile against the configured runtime tier, using a **9-cell pairing matrix**. `contracts/admission/runtime-tokens.schema.json` carries it as nine `allOf` branches over a closed profile enum — and nothing guarded it.

## Deleting a branch leaves the file valid

Measured with the pinned tool the `json-schema` gate runs — `ajv-cli@5.0.0 compile --spec=draft2020` exits 0 and prints "schema is valid" on a matrix with `(untrusted, runc)` removed. The pair that branch covered is then unvalidated at admission, and the most dangerous cell in the table is the one a careless edit is likeliest to touch.

## Axes derived, not restated

The profiles and tiers come **from the schema**, and the cartesian product is required. Enumerating the nine pairs in the checker would duplicate the contract and drift from it; deriving them keeps one source of truth while still refusing a missing cell, an unpaired profile, a duplicate branch, and an empty matrix.

## This row nearly took a false exemption

`workload_trust_profile`, `workload-trust`, `trust profile` and `admission` all read **ABSENT** to the coverage probe — because `contracts/` is outside `SUBJECT_DIRS`, not because the subject is missing. Grepping `contracts/` directly found the profile enum and the matrix. The probe's blind spot at the repository root was fixed in #545; this is the same shape one directory over.

## Verification

| Mutation | Result |
|---|---|
| delete the `(untrusted, runc)` branch | red |
| add a profile with no cells | red |
| empty the matrix | red |
| restore | green |

Coverage 25 -> 26 of 190; unexplained ceiling 38 -> 37. Meta-gate 26 of 26.

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **New Features**
  * Added validation to ensure every workload trust profile and deployment tier pairing is covered by the admission contract.
  * Added clear error reporting for missing, duplicate, or invalid pairing definitions.
  * Added a self-test mode to verify checker behavior.

* **Bug Fixes**
  * Prevented incomplete admission matrices from passing validation unnoticed.

* **Tests**
  * Added automated workflow checks for the complete pairing matrix.
  * Increased the required non-functional requirement coverage threshold from 25 to 26.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->