### PR TITLE
fix(nfr): excuse NFR-SEC-39 by the emitter and the profile it needs

### DIFF
--- a/scripts/check-nfr-coverage.py
+++ b/scripts/check-nfr-coverage.py
@@ -121,7 +121,7 @@ COMMITTED_FLOOR = 26
 # there and invisible. A ceiling that only ever falls would have locked the
 # blind spot in permanently -- the honest move is to raise it once, say why, and
 # resume the ratchet from the wider number.
-UNEXPLAINED_CEILING = 35
+UNEXPLAINED_CEILING = 34
 
 NFR_ID = re.compile(r"NFR-[A-Z]+-[A-Za-z0-9]+(?:-[A-Za-z0-9]+)*")
 MANIFESTO = "docs/architecture/manifesto/02-nfrs.md"
@@ -567,6 +567,20 @@ ABSENT_SUBJECT = (
     # rather than an action, so the exemption expires when the thing that
     # needs erasing exists.
     "mount-cache",
+    # NFR-SEC-39 wants an audit event `config.trust_profile.downgraded` within
+    # 30 s of a deployment being reconfigured to a weaker runtime tier. Two
+    # things it needs are absent: the audit emitter (see `host-authored`) and
+    # any notion of a declared trust profile in the implementation.
+    # config.trust_profile.downgraded, trust_profile and siem all return
+    # nothing here, and all three ARE described in contracts/ -- so this is
+    # specified-but-unbuilt, which the run now reports.
+    #
+    # Keyed on `trust_profile`: it appears in exactly one unexplained row. Note
+    # NFR-SEC-38 is ARMED on the same vocabulary, because its pairing matrix is
+    # a contract artifact that exists; this row needs a running emitter, which
+    # does not. Contract present, implementation absent -- the distinction the
+    # two probes now keep apart.
+    "trust_profile",
     # NFR-SEC-84 asks for a CSRF token on state-mutating requests, after an
     # embed-token-verified browser session (NFR-SEC-82). No browser credential
     # exists here: probed for set_cookie / request.cookies / Set-Cookie in


### PR DESCRIPTION
NFR-SEC-39 wants an audit event `config.trust_profile.downgraded` within 30 s of a
deployment being reconfigured to a weaker runtime tier, or of a trust profile
being downgraded with sessions live.

Two things it needs are absent:

| | |
|---|---|
| the audit emitter | `audit` appears **zero** times in the server (#563) |
| a declared trust profile | `config.trust_profile.downgraded`, `trust_profile`, `siem` — all absent |

All three **are** described in `contracts/`, so this is specified-but-unbuilt
rather than unconsidered — which the run now reports on every invocation (#570).

## The pairing with NFR-SEC-38

The two share a vocabulary and get **opposite** verdicts, which is worth stating:

- **SEC-38 is armed** on `trust_profile` — its 9-cell matrix is a contract
  artifact that exists and can be checked as it stands (#569).
- **SEC-39 is excused** — it needs a *running emitter* to produce a timed event,
  which does not exist.

Contract present, implementation absent: exactly the distinction the subject and
contract probes now keep apart. Verified that adding this exemption leaves SEC-38
armed.

## Verification

Planting a file that mentions a `trust_profile` puts NFR-SEC-39 straight back.

Unexplained ceiling 35 -> 34. Coverage unchanged at 26 of 190.

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Bug Fixes**
  * Improved non-functional requirement coverage checks to more accurately distinguish verifiable implementation requirements from contract-only requirements.
  * Updated coverage reporting to prevent missing trust-profile implementation details from being incorrectly flagged when they can be validated through continuous integration.
  * Refined the coverage threshold used to identify unexplained requirements, improving the accuracy and consistency of validation results.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->