### PR TITLE
fix(nfr): excuse NFR-FLEX-02 by the gVisor rung the ladder is missing

### DIFF
--- a/scripts/check-nfr-coverage.py
+++ b/scripts/check-nfr-coverage.py
@@ -121,7 +121,7 @@ COMMITTED_FLOOR = 26
 # there and invisible. A ceiling that only ever falls would have locked the
 # blind spot in permanently -- the honest move is to raise it once, say why, and
 # resume the ratchet from the wider number.
-UNEXPLAINED_CEILING = 31
+UNEXPLAINED_CEILING = 30
 
 NFR_ID = re.compile(r"NFR-[A-Z]+-[A-Za-z0-9]+(?:-[A-Za-z0-9]+)*")
 MANIFESTO = "docs/architecture/manifesto/02-nfrs.md"
@@ -618,6 +618,22 @@ ABSENT_SUBJECT = (
     # elevation at all, so it would revoke the exemption without the mechanism
     # this row is about.
     "just-in-time",
+    # NFR-FLEX-02 is the sandbox runtime LADDER: runc and gVisor in v1, both
+    # buildable from the same artefact. One rung exists -- the chart documents
+    # a "runc fallback" -- and the gVisor rung does not: gvisor and runsc
+    # return nothing in the implementation, and the only runsc mention in the
+    # tree is a roadmap document, i.e. a plan.
+    #
+    # Keyed on `runtime ladder`, which appears in exactly one row. `gvisor`
+    # would ALSO match NFR-SEC-65, where it is one of two tiers listed in a row
+    # about teardown ordering -- a live gap recorded in #553, with containers
+    # that do exist. Sweeping it under a ladder exemption would hide a real
+    # defect behind an unrelated absence. Verified SEC-65 stays unexplained.
+    #
+    # Reading the runc hits is what made the ladder's state clear: nearly every
+    # one is the substring inside "truncate"/"truncation". The real ones are
+    # the chart's runc-fallback documentation.
+    "runtime ladder",
     # NFR-SEC-84 asks for a CSRF token on state-mutating requests, after an
     # embed-token-verified browser session (NFR-SEC-82). No browser credential
     # exists here: probed for set_cookie / request.cookies / Set-Cookie in


### PR DESCRIPTION
NFR-FLEX-02 is the sandbox runtime **ladder**: `runc` and gVisor in v1, both
buildable from the same artefact.

One rung exists — the chart documents a *"runc fallback"*. The gVisor rung does
not: `gvisor` and `runsc` return nothing in the implementation, and the only
`runsc` mention anywhere in the tree is a roadmap document, which is a plan
rather than a rung.

## `gvisor` was the obvious key and is wrong

It **also** matches NFR-SEC-65, where it is one of two tiers listed in a row about
host-driven teardown ordering — a live gap recorded in #553, with containers that
*do* exist. Sweeping it under a ladder exemption would hide a real defect behind
an unrelated absence.

Keyed on `runtime ladder`, which appears in exactly one row. Verified NFR-SEC-65
stays unexplained.

## What reading the hits showed

Nearly every `runc` occurrence in the tree is the substring inside **"truncate"**
and **"truncation"** — dozens of them across the server, the patches, the CSS. The
genuine ones are the chart's runc-fallback documentation. A count of `runc`
matches would have said the rung was everywhere.

## Verification

Planting a template that mentions a runtime ladder puts NFR-FLEX-02 straight back.

Unexplained ceiling 31 -> 30. Coverage unchanged at 26 of 190.

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Chores**
  * Updated coverage validation thresholds.
  * Runtime-ladder requirements can remain exempt when no implementation exists.
  * Tightened the maximum number of unexplained coverage items from 31 to 30.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->