### PR TITLE
fix(nfr): excuse NFR-FLEX-15 by the egress ladder none of whose rungs ship

### DIFF
--- a/scripts/check-nfr-coverage.py
+++ b/scripts/check-nfr-coverage.py
@@ -121,7 +121,7 @@ COMMITTED_FLOOR = 26
 # there and invisible. A ceiling that only ever falls would have locked the
 # blind spot in permanently -- the honest move is to raise it once, say why, and
 # resume the ratchet from the wider number.
-UNEXPLAINED_CEILING = 30
+UNEXPLAINED_CEILING = 29
 
 NFR_ID = re.compile(r"NFR-[A-Z]+-[A-Za-z0-9]+(?:-[A-Za-z0-9]+)*")
 MANIFESTO = "docs/architecture/manifesto/02-nfrs.md"
@@ -634,6 +634,19 @@ ABSENT_SUBJECT = (
     # one is the substring inside "truncate"/"truncation". The real ones are
     # the chart's runc-fallback documentation.
     "runtime ladder",
+    # NFR-FLEX-15 is the EGRESS ladder: deny-all, transparent pass-through,
+    # egress-wide bump. None of the three rungs ships. deny-all, pass-through,
+    # egress-wide and "egress ladder" all return nothing in the implementation.
+    #
+    # `egress` itself IS present, which is why the key is a rung and not the
+    # word: the hits are helm/.../networkpolicy.yaml and its values, and that
+    # template renders NOTHING -- networkPolicy.enabled is false, so even the
+    # bottom rung is absent from a default install (#541).
+    #
+    # Keyed on `deny-all`. `egress-wide` would also match NFR-SEC-05, kept as a
+    # live gap deliberately when NFR-SEC-31 was excused: its subject (a single
+    # forward proxy) is present here. Verified SEC-05 stays unexplained.
+    "deny-all",
     # NFR-SEC-84 asks for a CSRF token on state-mutating requests, after an
     # embed-token-verified browser session (NFR-SEC-82). No browser credential
     # exists here: probed for set_cookie / request.cookies / Set-Cookie in


### PR DESCRIPTION
NFR-FLEX-15 is the egress **ladder**: deny-all · transparent pass-through · egress-wide bump, chosen per need rather than fixed.

None of the three rungs ships — `deny-all`, `pass-through`, `egress-wide` and `egress ladder` all return nothing in the implementation.

## Why the key is a rung, not `egress`

`egress` itself **is** present. The hits are `helm/computer-use-server/networkpolicy.yaml` and its values — and that template renders **nothing**: `networkPolicy.enabled` is `false`, so even the bottom rung is absent from a default install (#541). Re-measured here rather than carried over from the earlier finding; the value is still false.

## `egress-wide` would have been wrong

It also matches **NFR-SEC-05**, kept as a live gap deliberately when NFR-SEC-31 was excused — SEC-05's own subject, a single forward proxy, is present in this tree. Verified SEC-05 stays unexplained.

## Verification

Planting a template that mentions a deny-all rung puts NFR-FLEX-15 straight back.

Unexplained ceiling 30 -> 29. Coverage unchanged at 26 of 190.

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Bug Fixes**
  * Tightened coverage validation by lowering the maximum number of unexplained items.
  * Updated exemption handling to account for deny-all cases while continuing to require coverage for NFR-SEC-05.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->