### PR TITLE
fix(nfr): excuse NFR-MAINT-09 by the mutation harness that does not exist

### DIFF
--- a/scripts/check-nfr-coverage.py
+++ b/scripts/check-nfr-coverage.py
@@ -121,7 +121,7 @@ COMMITTED_FLOOR = 26
 # there and invisible. A ceiling that only ever falls would have locked the
 # blind spot in permanently -- the honest move is to raise it once, say why, and
 # resume the ratchet from the wider number.
-UNEXPLAINED_CEILING = 29
+UNEXPLAINED_CEILING = 28
 
 NFR_ID = re.compile(r"NFR-[A-Z]+-[A-Za-z0-9]+(?:-[A-Za-z0-9]+)*")
 MANIFESTO = "docs/architecture/manifesto/02-nfrs.md"
@@ -431,6 +431,17 @@ ABSENT_MECHANISM = (
     # whitelist, which is a list of files that MAY exist, not a mechanism.
     "per-pr + nightly",
     "threat-model pass",
+    # NFR-MAINT-09 wants a mutation-testing score >= 60% on the auth, sandbox,
+    # audit and egress packages, reported per release. No mutation harness
+    # exists: mutmut, stryker and cosmic-ray return nothing across .github/,
+    # scripts/ and tests/, and none appears in requirements.txt or package.json.
+    #
+    # The only hit for "mutation test" anywhere is a COMMENT in this file --
+    # the sentence explaining that NFR-MAINT-09's `audit` is a package name.
+    # armed_ids() and mechanism_is_absent() both exclude this file, so the
+    # exemption does not rest on its own prose; verified by reading the hit
+    # rather than trusting the exclusion.
+    "mutation-testing",
 )
 
 # The second reason an id cannot be armed: the SUBJECT does not exist. A
@@ -766,6 +777,7 @@ MECHANISM_PROBE = {
     "per-template test": "per-template",
     "per-pr + nightly": "promptfoo",
     "threat-model pass": "threagile",
+    "mutation-testing": "mutmut",
 }
 
 


### PR DESCRIPTION
NFR-MAINT-09 wants a mutation-testing score ≥ 60% on the auth, sandbox, audit and egress packages, reported per release.

No mutation harness exists: `mutmut`, `stryker` and `cosmic-ray` return nothing across `.github/`, `scripts/` and `tests/`, and none appears in `requirements.txt` or `package.json`.

## Recorded as an absent MECHANISM, not an absent subject

That is what it is — the packages under test are ordinary source; what is missing is the tool that would score them.

The needle is `mutmut`, a tool name that can only appear as an *invocation* — following the rule the replay-test needle paid for (#573): a needle short enough to appear in prose revokes an exemption silently.

## One check worth stating

The only hit for "mutation test" anywhere in `scripts/` is a **comment in this very file** — the sentence explaining that NFR-MAINT-09's `audit` is a package name rather than an audit log. Both `armed_ids()` and `mechanism_is_absent()` exclude this file, so the exemption does not rest on its own prose. I read the hit rather than trusting the exclusion to be there.

## Verification

Planting a workflow that runs `mutmut run` puts NFR-MAINT-09 straight back.

Unexplained ceiling 29 -> 28. Coverage unchanged at 26 of 190.

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Bug Fixes**
  * Tightened the CI quality gate by lowering the allowed unexplained coverage ceiling.
  * Added mutation-testing checks to accurately identify when mutation-testing tooling is available.
  * Documented the current absence of a mutation-testing harness and updated validation behavior accordingly.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->