### PR TITLE
fix(nfr): excuse NFR-IC-01 by the human-oversight channel that does not exist

### DIFF
--- a/scripts/check-nfr-coverage.py
+++ b/scripts/check-nfr-coverage.py
@@ -121,7 +121,7 @@ COMMITTED_FLOOR = 26
 # there and invisible. A ceiling that only ever falls would have locked the
 # blind spot in permanently -- the honest move is to raise it once, say why, and
 # resume the ratchet from the wider number.
-UNEXPLAINED_CEILING = 27
+UNEXPLAINED_CEILING = 26
 
 NFR_ID = re.compile(r"NFR-[A-Z]+-[A-Za-z0-9]+(?:-[A-Za-z0-9]+)*")
 MANIFESTO = "docs/architecture/manifesto/02-nfrs.md"
@@ -677,6 +677,17 @@ ABSENT_SUBJECT = (
     # taken from the target column ("capability negotiation") would match
     # nothing at all. `matrix test` would also hit NFR-FLEX-13, which is armed.
     "l4↔l1",
+    # NFR-IC-01 is human-oversight notification latency -- how fast a human
+    # supervisor learns something needs their attention. There is no channel to
+    # a human at all: human-oversight, notification latency and oversight
+    # return nothing in the implementation.
+    #
+    # `notification` DOES appear, and every hit is protocol machinery rather
+    # than a person: MCP notifications/resources/list_changed, MCP progress
+    # notifications, an inotify watcher, and an XSS payload in a security test.
+    # Keyed on `human-oversight` so the exemption expires when a channel to a
+    # HUMAN appears, not when another protocol message does.
+    "human-oversight",
     # NFR-SEC-84 asks for a CSRF token on state-mutating requests, after an
     # embed-token-verified browser session (NFR-SEC-82). No browser credential
     # exists here: probed for set_cookie / request.cookies / Set-Cookie in


### PR DESCRIPTION
NFR-IC-01 is human-oversight notification latency — how fast a **human supervisor** learns that something needs their attention.

There is no channel to a human at all: `human-oversight`, `notification latency` and `oversight` return nothing in the implementation.

## `notification` is present and is all machinery

| Hit | What it is |
|---|---|
| `mcp_resources.py:111` | MCP `notifications/resources/list_changed` |
| `app.py:1462` | MCP progress notifications |
| `app.py:1377` | an inotify watcher |
| `security.py:27` | an XSS payload in a test |

A key on that word would read the protocol as an oversight channel. Keyed on `human-oversight`, so the exemption expires when a channel to a **human** appears rather than when another protocol message does.

## Verification

Planting a file that mentions a human-oversight notification puts NFR-IC-01 straight back.

Unexplained ceiling 27 -> 26. Coverage unchanged at 26 of 190.

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Bug Fixes**
  * Improved compliance validation by refining unexplained-coverage thresholds.
  * Updated validation behavior for human-oversight notification requirements when no notification channel is implemented.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->