### PR TITLE
fix(nfr): excuse three obligations discharged by documents, not code

### DIFF
--- a/scripts/check-nfr-coverage.py
+++ b/scripts/check-nfr-coverage.py
@@ -121,7 +121,7 @@ COMMITTED_FLOOR = 26
 # there and invisible. A ceiling that only ever falls would have locked the
 # blind spot in permanently -- the honest move is to raise it once, say why, and
 # resume the ratchet from the wider number.
-UNEXPLAINED_CEILING = 24
+UNEXPLAINED_CEILING = 21
 
 NFR_ID = re.compile(r"NFR-[A-Z]+-[A-Za-z0-9]+(?:-[A-Za-z0-9]+)*")
 MANIFESTO = "docs/architecture/manifesto/02-nfrs.md"
@@ -701,6 +701,22 @@ ABSENT_SUBJECT = (
     # publishes rather than by code, like the retention and sub-processor rows
     # already excused above.
     "tlpt",
+    # Three more obligations discharged by a document rather than by code, each
+    # keyed separately so they expire on their own artefact.
+    #
+    # NFR-COMP-06: NYDFS contractual-clause completeness, 8 clauses populated
+    # per release. nydfs, contractual-clause, acceptable-use and training-data
+    # all return nothing -- these are contract terms a lawyer writes, and no
+    # clause register exists to count against.
+    "nydfs",
+    # NFR-COMP-24: NIS2 Art. 23 incident-reporting cascade, 24 h early-warning
+    # plus 72 h notification. The telemetry hook it names would be code, but
+    # the cascade itself is a reporting procedure; nis2 returns nothing.
+    "nis2",
+    # NFR-MAINT-13: external pen-test cadence, summary in the TPRM pack.
+    # Annual cadence is a procurement commitment, and the pack does not exist:
+    # pen-test and tprm both return nothing.
+    "pen-test",
     # NFR-SEC-84 asks for a CSRF token on state-mutating requests, after an
     # embed-token-verified browser session (NFR-SEC-82). No browser credential
     # exists here: probed for set_cookie / request.cookies / Set-Cookie in


### PR DESCRIPTION
**NFR-COMP-06** (NYDFS contractual-clause completeness, 8 clauses per release), **NFR-COMP-24** (NIS2 Art. 23 incident-reporting cascade) and **NFR-MAINT-13** (external pen-test cadence, summary in the TPRM pack) are all obligations a person discharges by writing and publishing a document.

`nydfs`, `nis2`, `contractual-clause`, `acceptable-use`, `training-data`, `pen-test` and `tprm` all return nothing in the implementation.

## Three keys, not one

They are satisfied by three different artefacts, written by three different people at three different times. A shared compliance-shaped key would mean the first one landing revokes the other two.

Probed each independently:

| Planted | Returns |
|---|---|
| `nydfs` | COMP-06 alone |
| `nis2` | COMP-24 alone |
| `pen-test` | MAINT-13 alone |

## What stays unexplained on purpose

Of the 24 rows the ratchet still listed, eight are findings already filed as **real gaps** — #530, #536, #540, #541, #549, #552, #553, #561, #565, #566, #572. Those are deliberately not excused: their subjects exist and the defect is real.

The exemption list and the findings list partition the remainder between *"nothing to check yet"* and *"something is wrong"*. This moves three rows into the first and leaves the second untouched.

Unexplained ceiling 24 -> 21. Coverage unchanged at 26 of 190.

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

- **Bug Fixes**
  - Updated compliance coverage checks to apply stricter unexplained-coverage limits.
  - Added support for independently handling regulatory and documentary exemptions related to NYDFS, NIS2, and penetration testing.
  - Matching requirements can remain appropriately excused when their related evidence is unavailable.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->