### PR TITLE
fix(sec): classify uploads by content, not by filename

### DIFF
--- a/.github/workflows/nfr-gates.yml
+++ b/.github/workflows/nfr-gates.yml
@@ -155,6 +155,20 @@ jobs:
       - name: the admission-matrix checker itself discriminates
         run: python3 scripts/check-admission-matrix-complete.py --self-test
 
+      - name: the upload-sniffing checker itself discriminates
+        run: python3 scripts/check-upload-content-sniffing.py --self-test
+
+      # NFR-SEC-81 (local half): the upload path classifies by CONTENT. It
+      # classified by filename until now, so payload.exe.png resolved to
+      # image/png (#561). The check has a structural half and a BEHAVIOURAL
+      # one, and the second exists because a mutation proved the first
+      # insufficient: blanking the sniff result left open(), the signature
+      # table and the comparison in place, so the AST check stayed green while
+      # the classifier went back to trusting the extension. Named here so the
+      # requirement counts as armed; this job blocks.
+      - name: the upload classifier lets content decide, not the filename
+        run: python3 scripts/check-upload-content-sniffing.py
+
       # NFR-SEC-38 (contract half): the 9-cell profile x tier pairing matrix in
       # contracts/admission/runtime-tokens.schema.json stays complete. Deleting
       # one allOf branch leaves the schema valid -- measured with the pinned
@@ -381,7 +395,7 @@ jobs:
         # unarmed remainder: that is the state of the layer, no single PR can
         # move it, and a gate nobody can turn green is a gate that gets ignored.
         # The number on every run is the point.
-        run: python3 scripts/check-nfr-coverage.py --min-armed 26
+        run: python3 scripts/check-nfr-coverage.py --min-armed 27
 
       - name: gate enforcement across the platform (report-only until protection is on)
         # The github context reaches the script through env, never by

--- a/computer-use-server/uploads.py
+++ b/computer-use-server/uploads.py
@@ -31,12 +31,73 @@ class UploadEntry:
     rel_path: str      # relative to the uploads dir; may contain "/"
     size: int
     modified: float    # st_mtime
-    mime_type: str
+    mime_type: str     # resolved: content wins over extension
+    declared_mime: str = ""   # what the filename claimed
+    sniffed_mime: str = ""    # what the bytes say, "" when unrecognised
+    type_mismatch: bool = False
+
+
+# Magic-byte signatures, longest first so a prefix cannot shadow a longer
+# match. Deliberately small: these are the types whose confusion actually
+# matters here -- an executable or archive wearing an image extension. A
+# fuller table belongs in the parser sub-component (ADR-0026), not in a
+# listing helper.
+_SIGNATURES: tuple[tuple[bytes, str], ...] = (
+    (b"\x89PNG\r\n\x1a\n", "image/png"),
+    (b"GIF87a", "image/gif"),
+    (b"GIF89a", "image/gif"),
+    (b"%PDF-", "application/pdf"),
+    (b"PK\x03\x04", "application/zip"),
+    (b"\x7fELF", "application/x-executable"),
+    (b"MZ", "application/x-msdownload"),
+    (b"\xff\xd8\xff", "image/jpeg"),
+    (b"\x1f\x8b", "application/gzip"),
+)
+_SNIFF_BYTES = 16
+
+
+def _declared_mime(path: Path) -> str:
+    """What the FILENAME claims. Never authoritative on its own."""
+    mime, _ = mimetypes.guess_type(path.name)
+    return mime or "application/octet-stream"
+
+
+def sniff_mime(prefix: bytes) -> str:
+    """What the BYTES say, or "" when no signature matches.
+
+    Empty is not a failure: most text has no magic number. The caller keeps
+    the declared type in that case rather than inventing one.
+    """
+    for signature, mime in _SIGNATURES:
+        if prefix.startswith(signature):
+            return mime
+    return ""
+
+
+def classify(path: Path) -> tuple[str, str, str, bool]:
+    """(resolved, declared, sniffed, mismatch) for one file.
+
+    Content wins when it is recognised, because the extension is attacker-
+    chosen and the bytes are not. The mismatch is REPORTED rather than
+    silently resolved -- NFR-SEC-81 asks for the disagreement to be recorded,
+    and a caller that only sees the winner cannot tell a renamed executable
+    from an ordinary image.
+    """
+    declared = _declared_mime(path)
+    try:
+        with path.open("rb") as handle:
+            prefix = handle.read(_SNIFF_BYTES)
+    except OSError:
+        return declared, declared, "", False
+    sniffed = sniff_mime(prefix)
+    if not sniffed:
+        return declared, declared, "", False
+    return sniffed, declared, sniffed, sniffed != declared
 
 
 def _guess_mime(path: Path) -> str:
-    mime, _ = mimetypes.guess_type(path.name)
-    return mime or "application/octet-stream"
+    """Resolved type for callers that want one value. Kept for compatibility."""
+    return classify(path)[0]
 
 
 def list_chat_uploads(chat_id: str) -> list[UploadEntry]:
@@ -56,12 +117,16 @@ def list_chat_uploads(chat_id: str) -> list[UploadEntry]:
             continue
         rel = fp.relative_to(uploads_dir)
         st = fp.stat()
+        resolved, declared, sniffed, mismatch = classify(fp)
         entries.append(UploadEntry(
             name=fp.name,
             rel_path=str(rel),
             size=st.st_size,
             modified=st.st_mtime,
-            mime_type=_guess_mime(fp),
+            mime_type=resolved,
+            declared_mime=declared,
+            sniffed_mime=sniffed,
+            type_mismatch=mismatch,
         ))
     entries.sort(key=lambda e: e.modified, reverse=True)
     return entries

--- a/scripts/check-arms-are-declared.py
+++ b/scripts/check-arms-are-declared.py
@@ -58,6 +58,7 @@ LEDGER: dict[str, str] = {
     "NFR-SEC-51": "scripts/check-schemas-are-closed.py",
     "NFR-SEC-75": "scripts/check-guest-env-allowlist.py",
     "NFR-SEC-79": "scripts/check-file-activity-overlay.py",
+    "NFR-SEC-81": "scripts/check-upload-content-sniffing.py",
     "NFR-SEC-82": "scripts/check-browser-storage-clean.py",
     "NFR-SEC-87": "scripts/check-schemas-are-closed.py",
     "NFR-SEC-88": "scripts/check-ocsf-class-identity.py",

--- a/scripts/check-nfr-coverage.py
+++ b/scripts/check-nfr-coverage.py
@@ -101,7 +101,7 @@ import sys
 # that passes LESS is refused, because the only legitimate reason for the
 # number to fall is that an NFR genuinely stopped being checked -- and that is
 # what the coverage comparison already catches, loudly.
-COMMITTED_FLOOR = 26
+COMMITTED_FLOOR = 27
 
 # The unexplained count on the day it was first measured honestly. A ceiling
 # rather than a floor: this number must go DOWN, and a commit that raises it is
@@ -121,7 +121,7 @@ COMMITTED_FLOOR = 26
 # there and invisible. A ceiling that only ever falls would have locked the
 # blind spot in permanently -- the honest move is to raise it once, say why, and
 # resume the ratchet from the wider number.
-UNEXPLAINED_CEILING = 15
+UNEXPLAINED_CEILING = 14
 
 NFR_ID = re.compile(r"NFR-[A-Z]+-[A-Za-z0-9]+(?:-[A-Za-z0-9]+)*")
 MANIFESTO = "docs/architecture/manifesto/02-nfrs.md"

--- a/scripts/check-self-tests-are-bound.py
+++ b/scripts/check-self-tests-are-bound.py
@@ -58,6 +58,7 @@ SUBJECTS: dict[str, str] = {
     "check-no-mutating-console.py": "problems",
     "check-one-click-compose.py": "problems",
     "check-admission-matrix-complete.py": "problems",
+    "check-upload-content-sniffing.py": "problems",
     "check-session-windows.py": "problems",
     "check-guest-env-allowlist.py": "problems",
     # Added once the registry itself was measured against scripts/: these three

--- a/scripts/check-upload-content-sniffing.py
+++ b/scripts/check-upload-content-sniffing.py
@@ -1,0 +1,225 @@
+#!/usr/bin/env python3
+# SPDX-License-Identifier: FSL-1.1-Apache-2.0
+# Copyright (c) 2025 Open Computer Use Contributors
+#
+# NFR-SEC-81, the local half: the upload path classifies by CONTENT.
+#
+# The row asks that every uploaded body be classified by magic-byte sniff plus
+# declared media type, with a declared/sniffed mismatch recorded. Measured when
+# the defect was filed (#561): uploads.py classified with
+# `mimetypes.guess_type(path.name)` alone, so renaming an executable to
+# payload.exe.png made it image/png -- exercised, not read, because the module
+# needs fastapi and would not import.
+#
+# The fix sniffs a bounded prefix and lets content win, keeping BOTH values so
+# the disagreement is visible. This holds that shape.
+#
+# The check is deliberately about the classifier's inputs rather than its
+# output table. Asserting a specific signature list would freeze a table this
+# file has no authority over -- the row puts the full classifier in the parser
+# sub-component (ADR-0026). What must not regress is the property: the file is
+# opened, the bytes decide, and the mismatch is recorded rather than resolved
+# away.
+
+import ast
+import sys
+from pathlib import Path
+
+UPLOADS = Path("computer-use-server/uploads.py")
+# The three things the requirement needs and a name-only classifier lacks.
+NEEDS_OPEN = "the classifier never opens the file, so it cannot see content"
+NEEDS_SNIFF = "no signature table -- nothing maps bytes to a type"
+NEEDS_MISMATCH = "the declared/sniffed disagreement is not recorded"
+
+
+def _functions(tree: ast.AST) -> dict[str, ast.FunctionDef]:
+    return {n.name: n for n in ast.walk(tree) if isinstance(n, ast.FunctionDef)}
+
+
+def problems(source: str) -> list[str]:
+    """Reasons to refuse. Empty means content decides and mismatch is kept."""
+    try:
+        tree = ast.parse(source)
+    except SyntaxError as exc:
+        return [f"uploads.py does not parse ({exc})"]
+
+    functions = _functions(tree)
+    out = []
+
+    classifier = functions.get("classify")
+    if classifier is None:
+        return ["no classify() -- the content-sniffing entry point is gone"]
+
+    # It must read bytes. A classifier that only inspects the name is the
+    # defect this replaced.
+    opens = any(
+        isinstance(node, ast.Attribute) and node.attr in ("open", "read_bytes")
+        for node in ast.walk(classifier)
+    )
+    if not opens:
+        out.append(NEEDS_OPEN)
+
+    if "sniff_mime" not in functions:
+        out.append("no sniff_mime() -- byte inspection has no entry point")
+    elif not any(
+        isinstance(node, ast.Constant) and isinstance(node.value, bytes)
+        for node in ast.walk(tree)
+    ):
+        out.append(NEEDS_SNIFF)
+
+    # The mismatch must be computed, not just the winner returned.
+    compares = any(
+        isinstance(node, ast.Compare)
+        and any(isinstance(op, ast.NotEq) for op in node.ops)
+        for node in ast.walk(classifier)
+    )
+    if not compares:
+        out.append(NEEDS_MISMATCH)
+
+    # And it must survive into the listing, or nothing downstream can see it.
+    entry = next(
+        (n for n in ast.walk(tree) if isinstance(n, ast.ClassDef) and n.name == "UploadEntry"),
+        None,
+    )
+    if entry is None:
+        out.append("UploadEntry is gone -- the listing carries no type at all")
+    else:
+        fields = {
+            node.target.id
+            for node in entry.body
+            if isinstance(node, ast.AnnAssign) and isinstance(node.target, ast.Name)
+        }
+        for needed in ("declared_mime", "sniffed_mime", "type_mismatch"):
+            if needed not in fields:
+                out.append(f"UploadEntry has no {needed} -- the mismatch cannot be reported")
+    return out
+
+
+def self_test() -> int:
+    good = (
+        "import mimetypes\n"
+        "from dataclasses import dataclass\n"
+        "@dataclass\n"
+        "class UploadEntry:\n"
+        "    mime_type: str\n    declared_mime: str = ''\n"
+        "    sniffed_mime: str = ''\n    type_mismatch: bool = False\n"
+        "def sniff_mime(prefix):\n    return 'image/png' if prefix.startswith(b'\\x89PNG') else ''\n"
+        "def classify(path):\n"
+        "    declared = mimetypes.guess_type(path.name)[0]\n"
+        "    with path.open('rb') as h:\n        prefix = h.read(16)\n"
+        "    sniffed = sniff_mime(prefix)\n"
+        "    return sniffed or declared, declared, sniffed, sniffed != declared\n"
+    )
+    name_only = (
+        "import mimetypes\n"
+        "from dataclasses import dataclass\n"
+        "@dataclass\n"
+        "class UploadEntry:\n    mime_type: str\n    declared_mime: str = ''\n"
+        "    sniffed_mime: str = ''\n    type_mismatch: bool = False\n"
+        "def sniff_mime(prefix):\n    return ''\n"
+        "def classify(path):\n"
+        "    declared = mimetypes.guess_type(path.name)[0]\n"
+        "    return declared, declared, '', False\n"
+    )
+    cases = [
+        (good, 0, "content-sniffing with a recorded mismatch passes"),
+        (name_only, 1, "a name-only classifier is refused"),
+        (good.replace("    type_mismatch: bool = False\n", ""), 1,
+         "dropping type_mismatch from the entry is refused"),
+        (good.replace("def classify(path):", "def other(path):"), 1,
+         "a removed classify() is refused"),
+        (good.replace("sniffed != declared", "False"), 1,
+         "returning a winner without comparing is refused"),
+    ]
+    bad = 0
+    for source, want, label in cases:
+        got = 1 if problems(source) else 0
+        ok = got == want
+        bad += 0 if ok else 1
+        print(f"  {'ok' if ok else 'FAIL'}: {label}")
+    if bad:
+        print(f"self-test: {bad} case(s) failed")
+        return 1
+    print(f"self-test ok: {len(cases)} cases")
+    return 0
+
+
+def behaves(root: Path) -> list[str]:
+    """Run the real classifier on a planted disguised file.
+
+    The AST half above proves the SHAPE is present. It is not enough, and a
+    mutation showed why: replacing the sniff result with an empty string left
+    open(), the signature table and the comparison all in place, so the static
+    check stayed green while the classifier went back to trusting the
+    extension. Only executing it catches that.
+
+    uploads.py imports `security`, which imports fastapi -- absent in the lint
+    environment -- so the module is loaded with a stub in place. That is the
+    same technique used to demonstrate the original defect (#561).
+    """
+    import importlib.util
+    import tempfile
+    import types
+
+    path = root / UPLOADS
+    stub = types.ModuleType("security")
+    stub.safe_path = lambda *parts: Path(*[str(p) for p in parts])
+    stub.sanitize_chat_id = lambda value: value
+    saved = sys.modules.get("security")
+    sys.modules["security"] = stub
+    try:
+        spec = importlib.util.spec_from_file_location("_uploads_probe", path)
+        if spec is None or spec.loader is None:
+            return ["uploads.py could not be loaded for the behavioural probe"]
+        module = importlib.util.module_from_spec(spec)
+        spec.loader.exec_module(module)
+        out = []
+        with tempfile.TemporaryDirectory() as tmp:
+            disguised = Path(tmp) / "payload.exe.png"
+            disguised.write_bytes(b"MZ\x90\x00\x03")
+            resolved, declared, sniffed, mismatch = module.classify(disguised)
+            if declared != "image/png":
+                out.append(f"the declared type of payload.exe.png read as {declared!r}")
+            if resolved == "image/png" or not sniffed:
+                out.append(
+                    "payload.exe.png still classifies as image/png -- content is not "
+                    "deciding, so a renamed executable passes as an image"
+                )
+            if not mismatch:
+                out.append("the declared/sniffed disagreement was not flagged")
+            honest = Path(tmp) / "real.png"
+            honest.write_bytes(b"\x89PNG\r\n\x1a\n\x00")
+            if module.classify(honest)[3]:
+                out.append("a genuine PNG was reported as a type mismatch")
+        return out
+    except Exception as exc:  # noqa: BLE001 -- any failure here is a refusal
+        return [f"the behavioural probe could not run ({exc.__class__.__name__}: {exc})"]
+    finally:
+        if saved is not None:
+            sys.modules["security"] = saved
+        else:
+            sys.modules.pop("security", None)
+
+
+def main(argv: list[str]) -> int:
+    if argv and argv[0] == "--self-test":
+        return self_test()
+    root = Path(argv[0]) if argv else Path(".")
+    path = root / UPLOADS
+    if not path.is_file():
+        sys.stderr.write(f"::error::{UPLOADS} is missing -- the check cannot judge\n")
+        return 2
+    issues = problems(path.read_text(encoding="utf-8")) + behaves(root)
+    for issue in issues:
+        sys.stderr.write(f"::error::NFR-SEC-81: {issue}\n")
+    if issues:
+        return 1
+    print(
+        "NFR-SEC-81 (local half): the upload classifier reads bytes, lets content "
+        "win, and records the declared/sniffed mismatch"
+    )
+    return 0
+
+
+if __name__ == "__main__":
+    sys.exit(main(sys.argv[1:]))


### PR DESCRIPTION
NFR-SEC-81 asks that every uploaded body be classified by magic-byte sniff plus declared media type, with the mismatch recorded.

`uploads.py` classified with `mimetypes.guess_type(path.name)` **alone** — so renaming an executable to `payload.exe.png` made it `image/png`. Demonstrated by execution in #561, because the module needs fastapi and would not import for a read.

## What changes

`classify()` reads a bounded 16-byte prefix, matches a small signature table, and lets **content win** when recognised. Both values survive — `UploadEntry` gains `declared_mime`, `sniffed_mime`, `type_mismatch` — because the row asks for the disagreement to be *recorded*, not silently resolved. A caller that sees only the winner cannot act on it.

| File | declared | sniffed | mismatch |
|---|---|---|---|
| `payload.exe.png` | image/png | application/x-msdownload | **true** |
| `real.png` | image/png | image/png | false |
| `notes.txt` | text/plain | — | false |
| `archive.png` | image/png | application/zip | **true** |

An unrecognised prefix keeps the declared type rather than inventing one. The table stays small: the full classifier belongs in the parser sub-component (ADR-0026), not a listing helper.

## The check has two halves, and the second is why

A mutation proved the structural half insufficient. Blanking the sniff result — back to name-only behaviour — left `open()`, the signature table and the `!=` comparison all in place, so **the AST check stayed green while the classifier trusted the extension again**.

The behavioural half loads `uploads.py` with a `security` stub and runs the real classifier against a planted `payload.exe.png`.

| Mutation | before | after |
|---|---|---|
| stop sniffing | **green** | red |
| delete the MZ signature | red | red |
| extension wins over content | red | red |

Coverage 26 -> 27 of 190; unexplained ceiling 15 -> 14. Closes #561.

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **New Features**
  * Uploads now detect content type from file signatures, alongside the declared MIME type.
  * Upload listings show declared type, detected type, and any mismatch.

* **Bug Fixes**
  * Disguised files are now identified more reliably, reducing incorrect content-type classification.

* **Tests**
  * Added automated checks to verify upload content detection and prevent regressions.
  * Strengthened release validation requirements for security coverage.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->