### PR TITLE
fix(helm): declare the shutdown grace period instead of inheriting it

### DIFF
--- a/.github/workflows/nfr-gates.yml
+++ b/.github/workflows/nfr-gates.yml
@@ -158,6 +158,19 @@ jobs:
       - name: the upload-sniffing checker itself discriminates
         run: python3 scripts/check-upload-content-sniffing.py --self-test
 
+      - name: the grace-period checker itself discriminates
+        run: python3 scripts/check-grace-period-declared.py --self-test
+
+      # NFR-REL-11, the declared-value half only. Kubernetes defaults this
+      # field to 30 -- the same number the row fixes -- which is why declaring
+      # it matters: a default can be changed by a cluster policy or an
+      # admission webhook without the chart noticing, and a rendered manifest
+      # that omits the number gives an auditor nothing to read. The SIGTERM
+      # ladder and tmpdir clean-up are server behaviour and stay unclaimed
+      # (#530). Named here so the requirement counts as armed; this job blocks.
+      - name: the chart declares its shutdown grace period
+        run: python3 scripts/check-grace-period-declared.py
+
       # NFR-SEC-81 (local half): the upload path classifies by CONTENT. It
       # classified by filename until now, so payload.exe.png resolved to
       # image/png (#561). The check has a structural half and a BEHAVIOURAL
@@ -395,7 +408,7 @@ jobs:
         # unarmed remainder: that is the state of the layer, no single PR can
         # move it, and a gate nobody can turn green is a gate that gets ignored.
         # The number on every run is the point.
-        run: python3 scripts/check-nfr-coverage.py --min-armed 27
+        run: python3 scripts/check-nfr-coverage.py --min-armed 28
 
       - name: gate enforcement across the platform (report-only until protection is on)
         # The github context reaches the script through env, never by

--- a/helm/computer-use-server/templates/deployment.yaml
+++ b/helm/computer-use-server/templates/deployment.yaml
@@ -37,6 +37,12 @@ spec:
     spec:
       serviceAccountName: {{ include "computer-use-server.serviceAccountName" . }}
       automountServiceAccountToken: {{ .Values.serviceAccount.automountToken }}
+      # NFR-REL-11 states 30 s, and Kubernetes happens to default to 30 s too.
+      # Declaring it is not redundant: a default is not a decision, it can be
+      # changed by a cluster policy or an admission webhook without this chart
+      # noticing, and a rendered manifest that does not carry the number gives
+      # an auditor nothing to read. The value is what the requirement fixes.
+      terminationGracePeriodSeconds: {{ .Values.orchestrator.terminationGracePeriodSeconds }}
       {{- with .Values.podSecurityContext }}
       securityContext:
         {{- toYaml . | nindent 8 }}

--- a/helm/computer-use-server/values.yaml
+++ b/helm/computer-use-server/values.yaml
@@ -42,6 +42,12 @@ orchestrator:
   #                persistence.varLibDocker.persistentVolume.enabled=false.
   runtimeClassName: kata-qemu
 
+  # NFR-REL-11: cooperative shutdown. Declared rather than left to the
+  # Kubernetes default of the same value -- see the comment in deployment.yaml.
+  # Raising it gives in-flight MCP sessions longer to drain; lowering it below
+  # the server's own drain time truncates them.
+  terminationGracePeriodSeconds: 30
+
   # Single replica is the only supported topology — the pod owns the inner dockerd
   # and three RWO PVCs. Scaling out requires the K8sBackend rework (out of scope).
   replicas: 1

--- a/scripts/check-arms-are-declared.py
+++ b/scripts/check-arms-are-declared.py
@@ -47,6 +47,7 @@ LEDGER: dict[str, str] = {
     "NFR-IC-02": "scripts/check-no-mutating-console.py",
     "NFR-MAINT-05": "scripts/check-release-synthetic.py",
     "NFR-MAINT-AUDIT-SCHEMA": "scripts/check-audit-fanin-inv1.py",
+    "NFR-REL-11": "scripts/check-grace-period-declared.py",
     "NFR-SEC-07": "scripts/check-schemas-are-closed.py",
     "NFR-SEC-15": "tests/test-docker-image.sh",
     "NFR-SEC-16": "scripts/check-no-phone-home.py",

--- a/scripts/check-grace-period-declared.py
+++ b/scripts/check-grace-period-declared.py
@@ -1,0 +1,114 @@
+#!/usr/bin/env python3
+# SPDX-License-Identifier: FSL-1.1-Apache-2.0
+# Copyright (c) 2025 Open Computer Use Contributors
+#
+# NFR-REL-11, the declared-value half: the chart states its shutdown grace
+# period rather than inheriting one.
+#
+# The row's target is `terminationGracePeriodSeconds=30`, SIGTERM->5s->SIGKILL,
+# tmpdir clean <= 10 s. Only the first clause is a chart property; the other two
+# are server behaviour and are NOT claimed here (see #530 for the measurement of
+# all three).
+#
+# Kubernetes defaults this field to 30, which is the same number, and that
+# coincidence is exactly why the check exists. A default is not a decision: it
+# can be changed by a cluster policy or a mutating admission webhook without the
+# chart noticing, and a rendered manifest that does not carry the number gives
+# an auditor nothing to read. Measured when this was written: the field appeared
+# nowhere in helm/, so the deployment matched the requirement only by accident.
+#
+# The check reads the TEMPLATE and the VALUE rather than a rendered manifest,
+# because rendering needs required values supplied on the command line
+# (PUBLIC_BASE_URL and an mcpApiKey, per the chart's own schema) and a lint that
+# has to be handed secrets to run is a lint people skip.
+
+import re
+import sys
+from pathlib import Path
+
+DEPLOYMENT = Path("helm/computer-use-server/templates/deployment.yaml")
+VALUES = Path("helm/computer-use-server/values.yaml")
+FIELD = "terminationGracePeriodSeconds"
+# The row fixes 30 s. A deployment may not silently drift off it.
+REQUIRED = 30
+
+
+def template_declares(text: str) -> bool:
+    """True when the pod spec sets the field from values."""
+    return re.search(rf"^\s*{FIELD}:\s*\{{\{{", text, re.M) is not None
+
+
+def declared_value(text: str) -> int | None:
+    """The number values.yaml ships, or None when it is absent."""
+    found = re.search(rf"^\s*{FIELD}:\s*(\d+)\s*$", text, re.M)
+    return int(found.group(1)) if found else None
+
+
+def problems(template: str, values: str) -> list[str]:
+    """Reasons to refuse. Empty means the number is stated, not inherited."""
+    out = []
+    if not template_declares(template):
+        out.append(
+            f"the pod spec does not set {FIELD} -- the deployment would inherit "
+            f"the Kubernetes default, which is a coincidence rather than a decision"
+        )
+    value = declared_value(values)
+    if value is None:
+        out.append(f"values.yaml ships no {FIELD}, so the template has nothing to render")
+    elif value != REQUIRED:
+        out.append(
+            f"values.yaml ships {FIELD}={value}, and NFR-REL-11 fixes {REQUIRED}"
+        )
+    return out
+
+
+def self_test() -> int:
+    good_t = "spec:\n      " + FIELD + ": {{ .Values.orchestrator." + FIELD + " }}\n"
+    good_v = "orchestrator:\n  " + FIELD + ": 30\n"
+    cases = [
+        ((good_t, good_v), 0, "template plus a 30 s value passes"),
+        (("spec:\n      containers: []\n", good_v), 1, "a template that omits the field is refused"),
+        ((good_t, "orchestrator:\n  other: 1\n"), 1, "a missing value is refused"),
+        ((good_t, "orchestrator:\n  " + FIELD + ": 5\n"), 1, "a value off the fixed 30 is refused"),
+        ((good_t, "orchestrator:\n  " + FIELD + ": 300\n"), 1, "a longer window is refused too"),
+        (("spec:\n      " + FIELD + ": 30\n", good_v), 1,
+         "a hardcoded template value is refused -- it cannot be tuned per deployment"),
+    ]
+    bad = 0
+    for (template, values), want, label in cases:
+        got = 1 if problems(template, values) else 0
+        ok = got == want
+        bad += 0 if ok else 1
+        print(f"  {'ok' if ok else 'FAIL'}: {label}")
+    if bad:
+        print(f"self-test: {bad} case(s) failed")
+        return 1
+    print(f"self-test ok: {len(cases)} cases")
+    return 0
+
+
+def main(argv: list[str]) -> int:
+    if argv and argv[0] == "--self-test":
+        return self_test()
+    root = Path(argv[0]) if argv else Path(".")
+    for path in (DEPLOYMENT, VALUES):
+        if not (root / path).is_file():
+            sys.stderr.write(f"::error::{path} is missing -- the check cannot judge\n")
+            return 2
+    issues = problems(
+        (root / DEPLOYMENT).read_text(encoding="utf-8"),
+        (root / VALUES).read_text(encoding="utf-8"),
+    )
+    for issue in issues:
+        sys.stderr.write(f"::error::NFR-REL-11: {issue}\n")
+    if issues:
+        return 1
+    print(
+        f"NFR-REL-11 (declared-value half): the chart states {FIELD}={REQUIRED} "
+        f"rather than inheriting it"
+    )
+    return 0
+
+
+if __name__ == "__main__":
+    sys.exit(main(sys.argv[1:]))

--- a/scripts/check-nfr-coverage.py
+++ b/scripts/check-nfr-coverage.py
@@ -101,7 +101,7 @@ import sys
 # that passes LESS is refused, because the only legitimate reason for the
 # number to fall is that an NFR genuinely stopped being checked -- and that is
 # what the coverage comparison already catches, loudly.
-COMMITTED_FLOOR = 27
+COMMITTED_FLOOR = 28
 
 # The unexplained count on the day it was first measured honestly. A ceiling
 # rather than a floor: this number must go DOWN, and a commit that raises it is
@@ -121,7 +121,7 @@ COMMITTED_FLOOR = 27
 # there and invisible. A ceiling that only ever falls would have locked the
 # blind spot in permanently -- the honest move is to raise it once, say why, and
 # resume the ratchet from the wider number.
-UNEXPLAINED_CEILING = 14
+UNEXPLAINED_CEILING = 13
 
 NFR_ID = re.compile(r"NFR-[A-Z]+-[A-Za-z0-9]+(?:-[A-Za-z0-9]+)*")
 MANIFESTO = "docs/architecture/manifesto/02-nfrs.md"

--- a/scripts/check-self-tests-are-bound.py
+++ b/scripts/check-self-tests-are-bound.py
@@ -59,6 +59,7 @@ SUBJECTS: dict[str, str] = {
     "check-one-click-compose.py": "problems",
     "check-admission-matrix-complete.py": "problems",
     "check-upload-content-sniffing.py": "problems",
+    "check-grace-period-declared.py": "problems",
     "check-session-windows.py": "problems",
     "check-guest-env-allowlist.py": "problems",
     # Added once the registry itself was measured against scripts/: these three


### PR DESCRIPTION
NFR-REL-11 fixes `terminationGracePeriodSeconds=30`. The field appeared **nowhere** in `helm/`, so the deployment matched the requirement only because Kubernetes happens to default to the same number.

## The coincidence is the reason to declare it

A default is not a decision. A cluster policy or a mutating admission webhook can change it without this chart noticing, and a rendered manifest that does not carry the number gives an auditor nothing to read.

The value now lives in `values.yaml` and the pod spec renders it — verified by rendering the chart the way CI does, which needs `PUBLIC_BASE_URL` **and** an `mcpApiKey` on the command line before it produces anything at all.

## Only one clause is claimed

The row also states `SIGTERM→5s→SIGKILL` and tmpdir clean ≤ 10 s. Both are server behaviour, the server installs no signal handler, and #530 records all three measurements. Arming the whole row on a chart field would claim two properties nothing implements.

## Why the check reads source, not a render

Rendering requires secrets on the command line, and a lint that must be handed a key to run is a lint people skip.

| Mutation | Result |
|---|---|
| remove the field from the template | red |
| remove the value from values.yaml | red |
| drift the value to 5 | red |
| restore | green, chart still renders |

Coverage 27 -> 28 of 190; unexplained ceiling 14 -> 13. Partially addresses #530.

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **New Features**
  * Added configurable Kubernetes shutdown grace-period settings, defaulting to 30 seconds.
  * Added validation to ensure deployments declare the required 30-second grace period.

* **Bug Fixes**
  * Improved release safeguards by blocking deployments with missing or incorrect shutdown configuration.

* **Tests**
  * Added self-tests and coverage checks for shutdown grace-period validation.
  * Increased the minimum required non-functional requirement coverage.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->