### PR TITLE
test: cover cross-chat isolation, the config script, meta loading and the CDP name rule

### DIFF
--- a/tests/orchestrator/test_cdp_container_name.py
+++ b/tests/orchestrator/test_cdp_container_name.py
@@ -1,0 +1,95 @@
+# SPDX-License-Identifier: FSL-1.1-Apache-2.0
+# Copyright (c) 2025 Open Computer Use Contributors
+"""The CDP lookup sanitises chat_id differently, and that is deliberate.
+
+get_container_cdp_address does not call security.sanitize_chat_id. It applies
+its own rule -- `re.sub(r'[^a-zA-Z0-9_.-]', '-', chat_id.lower())` -- and the
+two disagree. Measured:
+
+    '../etc'  ->  local '..-etc'     strict REFUSED
+    'a.b'     ->  local 'a.b'        strict REFUSED
+    "x'y"     ->  local 'x-y'        strict REFUSED
+
+A second sanitiser next to a strict one usually means somebody forgot. Here it
+does not, and the reason is what this file records: the output becomes a DOCKER
+CONTAINER NAME, never a filesystem path. `sanitized_id` has four uses and every
+one feeds `owui-chat-{...}` into `containers.get`. Dots are legal in a container
+name and dangerous in a path, which is exactly why the strict rule rejects them
+and this one need not.
+
+So the property to hold is not "both rules agree" -- they must not. It is that
+the local rule maps every separator to a dash, so no input can produce a name
+that addresses a different container than intended, and that the result is
+never used as a path.
+"""
+
+import re
+import sys
+import unittest
+from pathlib import Path
+
+ROOT = Path(__file__).resolve().parent.parent.parent
+sys.path.insert(0, str(ROOT / "computer-use-server"))
+
+SANITISE = re.compile(r"[^a-zA-Z0-9_.-]")
+
+
+def _local_rule(chat_id: str) -> str:
+    """The rule as docker_manager applies it, restated so a drift is visible."""
+    return SANITISE.sub("-", chat_id.lower())
+
+
+class CdpContainerName(unittest.TestCase):
+    def test_the_source_still_applies_this_rule(self):
+        """If docker_manager's regex changes, this file's premise is stale."""
+        source = (ROOT / "computer-use-server" / "docker_manager.py").read_text(
+            encoding="utf-8"
+        )
+        self.assertIn(r"re.sub(r'[^a-zA-Z0-9_.-]', '-', chat_id)", source)
+
+    def test_separators_cannot_survive_into_the_name(self):
+        """A slash or backslash reaching containers.get would address elsewhere."""
+        for value in ("a/b", "a\\b", "../etc", "a b", "x'y", 'x"y', "a;b"):
+            with self.subTest(value=value):
+                self.assertNotRegex(_local_rule(value), r"[/\\ ;'\"]")
+
+    def test_ordinary_ids_are_unchanged(self):
+        for value in ("default", "abc123", "test-123", "a.b", "a_b"):
+            with self.subTest(value=value):
+                self.assertEqual(_local_rule(value), value)
+
+    def test_case_is_folded(self):
+        self.assertEqual(_local_rule("MixedCase"), "mixedcase")
+
+    def test_it_diverges_from_the_strict_rule_on_dots(self):
+        """Stated as a test so the divergence is a decision, not an accident.
+
+        A dot is legal in a container name and dangerous in a path. The strict
+        rule guards paths and rejects it; this one guards a name and need not.
+        """
+        from fastapi import HTTPException
+        from security import sanitize_chat_id
+
+        self.assertEqual(_local_rule("a.b"), "a.b")
+        with self.assertRaises(HTTPException):
+            sanitize_chat_id("a.b")
+
+    def test_the_sanitised_value_never_becomes_a_path(self):
+        """The premise of the whole divergence, asserted against the source."""
+        source = (ROOT / "computer-use-server" / "docker_manager.py").read_text(
+            encoding="utf-8"
+        )
+        for line in source.splitlines():
+            if "sanitized_id" not in line or line.strip().startswith("#"):
+                continue
+            if "sanitized_id =" in line:
+                continue
+            self.assertIn(
+                "owui-chat-",
+                line,
+                "sanitized_id reached something other than a container name",
+            )
+
+
+if __name__ == "__main__":
+    unittest.main()

--- a/tests/orchestrator/test_container_meta.py
+++ b/tests/orchestrator/test_container_meta.py
@@ -1,0 +1,80 @@
+# SPDX-License-Identifier: FSL-1.1-Apache-2.0
+# Copyright (c) 2025 Open Computer Use Contributors
+"""load_container_meta reads a per-chat file, and nothing tested it.
+
+Three properties, all already true, all one edit from not being.
+
+chat_id is sanitized before it becomes a path. _get_meta_path calls
+sanitize_chat_id, so a traversal is refused 400 rather than reading
+BASE_DATA_DIR/../etc/.meta.json. That guard is a separate import inside the
+function, which is exactly the kind of line a refactor drops.
+
+A corrupt file degrades to None rather than raising. The except is broad, which
+is right here -- a container whose metadata will not parse should be
+recreatable rather than un-restartable -- but a broad except is also how a
+guard stops discriminating, so the DEGRADE is asserted rather than assumed.
+
+And an absent file is None too, which is the ordinary case for a fresh chat and
+must not be confused with the corrupt one.
+"""
+
+import importlib
+import json
+import sys
+import tempfile
+import unittest
+from pathlib import Path
+
+ROOT = Path(__file__).resolve().parent.parent.parent
+sys.path.insert(0, str(ROOT / "computer-use-server"))
+
+import docker_manager  # noqa: E402
+from fastapi import HTTPException  # noqa: E402
+
+importlib.reload(docker_manager)
+
+
+class ContainerMeta(unittest.TestCase):
+    def setUp(self):
+        self._tmp = Path(tempfile.mkdtemp(prefix="ocu-meta-test-"))
+        self._saved = docker_manager.BASE_DATA_DIR
+        docker_manager.BASE_DATA_DIR = self._tmp
+
+    def tearDown(self):
+        docker_manager.BASE_DATA_DIR = self._saved
+
+    def _seed(self, chat_id: str, text: str) -> None:
+        target = self._tmp / chat_id
+        target.mkdir(parents=True, exist_ok=True)
+        (target / ".meta.json").write_text(text, encoding="utf-8")
+
+    def test_loads_saved_metadata(self):
+        self._seed("metachat", json.dumps({"user_email": "a@b.c", "mcp_servers": "x"}))
+        loaded = docker_manager.load_container_meta("metachat")
+        self.assertEqual(loaded["user_email"], "a@b.c")
+
+    def test_absent_metadata_is_none(self):
+        """The ordinary case for a fresh chat, not an error."""
+        self.assertIsNone(docker_manager.load_container_meta("never-existed"))
+
+    def test_corrupt_metadata_degrades_to_none(self):
+        """Asserted rather than assumed: a broad except is how a guard stops
+        discriminating, and the caller's recovery path depends on None."""
+        self._seed("corruptchat", "{not json at all")
+        self.assertIsNone(docker_manager.load_container_meta("corruptchat"))
+
+    def test_traversal_in_chat_id_is_refused(self):
+        """_get_meta_path sanitizes before joining. A refactor dropping that
+        import would read BASE_DATA_DIR/../etc/.meta.json instead."""
+        with self.assertRaises(HTTPException) as caught:
+            docker_manager.load_container_meta("../etc")
+        self.assertEqual(caught.exception.status_code, 400)
+
+    def test_meta_path_stays_under_the_data_dir(self):
+        resolved = docker_manager._get_meta_path("metachat")
+        self.assertTrue(str(resolved).startswith(str(self._tmp)))
+        self.assertTrue(str(resolved).endswith(".meta.json"))
+
+
+if __name__ == "__main__":
+    unittest.main()

--- a/tests/orchestrator/test_cross_chat_isolation.py
+++ b/tests/orchestrator/test_cross_chat_isolation.py
@@ -1,0 +1,92 @@
+# SPDX-License-Identifier: FSL-1.1-Apache-2.0
+# Copyright (c) 2025 Open Computer Use Contributors
+"""One chat cannot read another chat's uploads.
+
+test_mcp_resources covers the LISTING side: a fresh chat inherits no resources
+and sees none of another tenant's URIs. That is discovery, and discovery is not
+access -- a caller who already knows a path never asks for a listing.
+
+Nothing covered the read side. The property holds today (probed before writing
+this: both cross-chat rel_paths are refused 403), and it holds because
+read_chat_upload resolves the uploads directory per chat and hands rel_path to
+safe_path. Every part of that is one edit away from not being true, and the
+failure would be silent: a leak returns bytes rather than raising.
+
+The distinction from test_upload_read_path is the target. That file asserts a
+traversal LEAVING the base is refused. This asserts a traversal landing inside
+a SIBLING chat is refused too -- same mechanism, different consequence, and the
+one an operator would actually be asked about.
+"""
+
+import importlib
+import os
+import sys
+import tempfile
+import unittest
+from pathlib import Path
+
+ROOT = Path(__file__).resolve().parent.parent.parent
+
+
+class CrossChatIsolation(unittest.TestCase):
+    """Needs BASE_DATA_DIR set BEFORE uploads is imported."""
+
+    @classmethod
+    def setUpClass(cls):
+        cls._tmp = tempfile.mkdtemp(prefix="ocu-tenancy-test-")
+        os.environ["BASE_DATA_DIR"] = cls._tmp
+        sys.path.insert(0, str(ROOT / "computer-use-server"))
+        import uploads as uploads_mod
+
+        importlib.reload(uploads_mod)
+        cls.uploads = uploads_mod
+
+        from fastapi import HTTPException
+
+        cls.HTTPException = HTTPException
+
+        victim = Path(cls._tmp) / "chat-a" / "uploads"
+        victim.mkdir(parents=True, exist_ok=True)
+        (victim / "secret.txt").write_bytes(b"chat A private data")
+        neighbour = Path(cls._tmp) / "chat-b" / "uploads"
+        neighbour.mkdir(parents=True, exist_ok=True)
+        (neighbour / "own.txt").write_bytes(b"chat B data")
+
+    def test_a_chat_reads_its_own_file(self):
+        """The control: isolation that also blocks legitimate reads proves nothing."""
+        data, _mime = self.uploads.read_chat_upload("chat-b", "own.txt")
+        self.assertEqual(data, b"chat B data")
+
+    def test_climbing_into_a_sibling_chat_is_refused(self):
+        """The shape an attacker who knows the layout would try first."""
+        for rel in (
+            "../../chat-a/uploads/secret.txt",
+            "../chat-a/uploads/secret.txt",
+            "..%2F..%2Fchat-a%2Fuploads%2Fsecret.txt",
+        ):
+            with self.subTest(rel=rel):
+                with self.assertRaises((self.HTTPException, FileNotFoundError)) as caught:
+                    self.uploads.read_chat_upload("chat-b", rel)
+                exception = caught.exception
+                if isinstance(exception, self.HTTPException):
+                    self.assertEqual(exception.status_code, 403)
+
+    def test_a_sibling_chat_id_cannot_be_smuggled_as_a_path(self):
+        """chat_id is the other lever, and it is refused earlier with 400."""
+        with self.assertRaises(self.HTTPException) as caught:
+            self.uploads.read_chat_upload("chat-b/../chat-a", "uploads/secret.txt")
+        self.assertEqual(caught.exception.status_code, 400)
+
+    def test_listing_does_not_reveal_the_sibling(self):
+        """Discovery stays separated too, so neither half carries the property alone."""
+        names = {entry.rel_path for entry in self.uploads.list_chat_uploads("chat-b")}
+        self.assertEqual(names, {"own.txt"})
+
+    def test_the_victims_file_is_still_there(self):
+        """A refusal that deleted or emptied the target would also pass the above."""
+        data, _mime = self.uploads.read_chat_upload("chat-a", "secret.txt")
+        self.assertEqual(data, b"chat A private data")
+
+
+if __name__ == "__main__":
+    unittest.main()

--- a/tests/orchestrator/test_mcp_config_script.py
+++ b/tests/orchestrator/test_mcp_config_script.py
@@ -1,0 +1,92 @@
+# SPDX-License-Identifier: FSL-1.1-Apache-2.0
+# Copyright (c) 2025 Open Computer Use Contributors
+"""build_mcp_config_write_script builds a shell command, and nothing tested it.
+
+Two properties are worth pinning, and both are already true.
+
+The config is base64'd rather than interpolated. A server name or URL carrying
+a quote would otherwise break out of the python3 -c string -- the script is
+assembled by f-string, so escaping is the only thing standing between a config
+value and shell syntax, and base64 removes the question rather than answering
+it carefully.
+
+The token is not in the script. ANTHROPIC_AUTH_TOKEN is read from the
+container's own environment at runtime, so the command -- which is visible in
+`docker inspect`, in any exec log, and to anything that can read the process
+table -- carries no credential. NFR-SEC-75 requires exactly this shape, and the
+test states it as a property of the OUTPUT rather than of how the output is
+built.
+"""
+
+import base64
+import importlib
+import json
+import re
+import sys
+import unittest
+from pathlib import Path
+
+ROOT = Path(__file__).resolve().parent.parent.parent
+sys.path.insert(0, str(ROOT / "computer-use-server"))
+
+import docker_manager  # noqa: E402
+
+importlib.reload(docker_manager)
+
+
+class McpConfigWriteScript(unittest.TestCase):
+    def _script(self, config: dict) -> str:
+        return docker_manager.build_mcp_config_write_script(config)
+
+    def test_config_survives_the_round_trip(self):
+        """The payload must arrive intact, or the encoding is just obfuscation."""
+        config = {"mcpServers": {"ocu": {"url": "http://host:8081/mcp", "headers": {}}}}
+        script = self._script(config)
+        blob = re.search(r'b64decode\("([^"]+)"\)', script)
+        self.assertIsNotNone(blob, "the script no longer carries a base64 payload")
+        self.assertEqual(json.loads(base64.b64decode(blob.group(1))), config)
+
+    def test_a_quote_in_a_config_value_cannot_reach_the_shell(self):
+        """The reason base64 is there. An f-string offers no other protection."""
+        hostile = {
+            "mcpServers": {
+                "evil'; touch /tmp/pwned; #": {
+                    "url": 'http://x/"; rm -rf /; "',
+                    "headers": {},
+                }
+            }
+        }
+        script = self._script(hostile)
+        self.assertNotIn("touch /tmp/pwned", script)
+        self.assertNotIn("rm -rf /", script)
+        # And it still round-trips, so the defence is encoding rather than dropping.
+        blob = re.search(r'b64decode\("([^"]+)"\)', script)
+        self.assertEqual(json.loads(base64.b64decode(blob.group(1))), hostile)
+
+    def test_the_script_carries_no_token(self):
+        """NFR-SEC-75: the command is world-readable; the credential must not be in it."""
+        script = self._script({"mcpServers": {"ocu": {"headers": {}}}})
+        self.assertIn("os.environ.get(\"ANTHROPIC_AUTH_TOKEN\"", script)
+        self.assertNotIn("Bearer sk-", script)
+        for line in script.splitlines():
+            self.assertNotRegex(
+                line,
+                r"ANTHROPIC_AUTH_TOKEN\s*=\s*\S",
+                "the token is assigned a literal value in the script",
+            )
+
+    def test_a_token_shaped_value_in_the_config_is_still_encoded(self):
+        """If a caller puts a secret in the config, it must not appear in clear."""
+        config = {"mcpServers": {"ocu": {"headers": {"X-Key": "sk-ant-secret-value"}}}}
+        script = self._script(config)
+        self.assertNotIn("sk-ant-secret-value", script)
+
+    def test_enables_exactly_the_servers_it_was_given(self):
+        """The auto-approve list is derived, so a stale hardcoded name would show."""
+        script = self._script({"mcpServers": {"alpha": {}, "beta": {}}})
+        self.assertIn("enabledMcpjsonServers", script)
+        self.assertIn('c["mcpServers"].keys()', script)
+
+
+if __name__ == "__main__":
+    unittest.main()


### PR DESCRIPTION
Four test files, written after the module-level coverage gap was closed (#591, #592). Each pins a property that is **already true** and was held by nothing.

**1. One chat cannot read another chat's uploads.** `test_mcp_resources` covers the *listing* side — discovery is not access; a caller who knows a path never asks for a listing. Probed first: both cross-chat `rel_path`s are refused 403 today. Two cases exist to stop the suite passing for the wrong reason: a chat reading its **own** file, and the victim's file still readable afterwards.

**2. The MCP config write script.** `build_mcp_config_write_script` assembles a `python3 -c` command by f-string. The config is **base64'd rather than interpolated** — a server name of `evil'; touch /tmp/pwned; #` cannot reach the shell and still round-trips, so the defence is encoding rather than dropping. And **the token is not in the script**: read from the container's env at runtime, while the command is visible in `docker inspect`.

**3. `load_container_meta`.** Sanitises before pathing, degrades to `None` on corrupt JSON, `None` for an absent file. The degrade is **asserted rather than assumed** — a broad `except` is how a guard stops discriminating.

**4. The CDP lookup sanitises differently, on purpose.** `get_container_cdp_address` does not call `sanitize_chat_id`: `a.b` passes locally and is REFUSED strictly. A second sanitiser beside a strict one usually means somebody forgot — here it does not: the output becomes a Docker **container name**, never a path (all four uses feed `owui-chat-{...}`). A dot is legal in a name and dangerous in a path. The property is not "both agree" but that every separator maps to a dash and the value never reaches a path — asserted against the source.

**All mutation-probed**, including one that first reported *green*: widening the CDP character class to allow `/`. Shell quoting had prevented the edit applying at all; re-run through a file rather than a nested quote, it reds.

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Tests**
  * Added coverage for CDP container-name sanitization, including separator handling, case normalization, and identifier preservation.
  * Added validation for container metadata loading, malformed files, missing files, path traversal, and containment.
  * Added cross-chat file isolation tests to prevent unauthorized access.
  * Added MCP configuration script tests covering safe encoding, token protection, shell-injection resistance, and server selection.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->