### PR TITLE
fix(mcp): bound the tool-detail status line, as the text branch already was

### DIFF
--- a/computer-use-server/mcp_tools.py
+++ b/computer-use-server/mcp_tools.py
@@ -194,6 +194,11 @@ _TOOL_LABELS = {
 }
 
 
+# One line of status. The agent writes the log this is parsed from, so no
+# field in it has a natural bound.
+_STATUS_MAX_LEN = 80
+
+
 def parse_last_action(lines: list) -> Optional[str]:
     """
     Parse JSONL lines from Claude session log and return last meaningful action.
@@ -211,7 +216,7 @@ def parse_last_action(lines: list) -> Optional[str]:
                 content = data.get("message", {}).get("content", [])
                 for item in content:
                     if item.get("type") == "text":
-                        text = item.get("text", "")[:80]
+                        text = item.get("text", "")[:_STATUS_MAX_LEN]
                         text = text.replace('\n', ' ').strip()
                         if text:
                             last_action = text
@@ -219,6 +224,14 @@ def parse_last_action(lines: list) -> Optional[str]:
                         name = item.get("name", "unknown")
                         inp = item.get("input", {})
                         detail = get_tool_detail(name, inp)
+                        if detail:
+                            # The text branch above truncates and this one did
+                            # not, so a tool input carried its full length into
+                            # the status line -- measured at 5009 characters
+                            # through a `description` field, against 80 for the
+                            # same payload as text. The string reaches
+                            # send_progress as an MCP notification.
+                            detail = detail[:_STATUS_MAX_LEN]
                         tool_label = _TOOL_LABELS.get(name, name)
                         if detail:
                             last_action = f"{tool_label}: {detail}"

--- a/tests/orchestrator/test_parse_last_action.py
+++ b/tests/orchestrator/test_parse_last_action.py
@@ -83,6 +83,24 @@ class ParseLastAction(unittest.TestCase):
         result = mcp_tools.parse_last_action([_assistant(_text("x" * 500))])
         self.assertLessEqual(len(result), 80)
 
+    def test_a_tool_detail_is_bounded_too(self):
+        """The text branch truncated and the tool branch did not.
+
+        Measured before the fix: the same 5000-character payload produced 80
+        characters as text and 5009 as a tool description. The string reaches
+        send_progress as an MCP notification, so an unbounded field is a
+        protocol message sized by whatever the agent wrote.
+        """
+        result = mcp_tools.parse_last_action(
+            [_assistant(_tool("Bash", description="y" * 5000))]
+        )
+        self.assertLessEqual(len(result), 120, "tool detail is not bounded")
+
+    def test_a_short_tool_detail_is_not_truncated(self):
+        """The bound must not eat ordinary values."""
+        result = mcp_tools.parse_last_action([_assistant(_tool("Bash", description="ls -la"))])
+        self.assertIn("ls -la", result)
+
     def test_a_wrong_typed_content_field_does_not_raise(self):
         """content as a string rather than a list -- TypeError is caught."""
         line = json.dumps({"type": "assistant", "message": {"content": "not-a-list"}})


### PR DESCRIPTION
`parse_last_action` truncates a text item to 80 characters. It did **not** truncate a tool detail at all.

Measured with the same 5000-character payload:

| branch | length |
|---|---|
| text | 80 |
| tool `description` | **5009** |

## The string is not internal

It reaches `send_progress` as an **MCP progress notification** (`mcp_tools.py:1156`) — so an unbounded field means a protocol message sized by whatever the agent wrote into its own log.

## What changed

The bound is now a named constant rather than a repeated literal, and it is applied **after** the label is chosen, so `Running: ls -la` stays intact while a long description is cut.

The asymmetry existed because the two branches were written separately. Naming the constant is what stops the next branch repeating it.

## Two tests

A 5000-character description must produce a bounded line, **and** a short one must survive untouched — a bound that ate ordinary values would satisfy the first assertion alone.

Probed: removing the truncation reds exactly the new test.

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Bug Fixes**
  * Limited status messages and progress notifications to 80 characters.
  * Prevented oversized tool descriptions from appearing in status updates.
  * Preserved short status messages without altering their content.

* **Tests**
  * Added coverage for long and short tool descriptions to verify message length limits.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->