### PR TITLE
fix(sec): strip CR/LF/NUL from a request value before it becomes a header

### DIFF
--- a/computer-use-server/docker_manager.py
+++ b/computer-use-server/docker_manager.py
@@ -29,6 +29,7 @@ import docker
 from docker.utils.socket import frames_iter, demux_adaptor, consume_socket_output
 
 import skill_manager
+from security import header_safe
 from context_vars import (
     current_chat_id, current_user_email, current_user_name,
     current_gitlab_token, current_gitlab_host,
@@ -596,7 +597,15 @@ def _create_container(chat_id: str, container_name: str) -> docker.models.contai
         # Anthropic-specific custom header — only emit for the claude runtime
         # so codex / opencode containers do not get spurious anthropic env.
         if SUBAGENT_CLI == "claude":
-            extra_env["ANTHROPIC_CUSTOM_HEADERS"] = f"x-openwebui-user-email: {user_email}"
+            # header_safe strips CR/LF/NUL: user_email arrives from a request
+            # header unvalidated, and this value is a header LIST parsed by
+            # Claude Code inside the guest (#603). Shell injection is already
+            # closed -- the entrypoint exports this quoted -- but a separator
+            # in the value would add headers to upstream calls that carry the
+            # deployment's own credential.
+            extra_env["ANTHROPIC_CUSTOM_HEADERS"] = (
+                f"x-openwebui-user-email: {header_safe(user_email)}"
+            )
 
     # Workspace volume for this chat
     workspace_volume = f"chat-{chat_id}-workspace"

--- a/computer-use-server/mcp_tools.py
+++ b/computer-use-server/mcp_tools.py
@@ -81,6 +81,7 @@ from typing import Optional, List, Annotated
 from mcp.server.fastmcp import FastMCP, Context
 from pydantic import Field
 import skill_manager
+from security import header_safe
 from context_vars import (
     current_chat_id, current_user_email, current_user_name,
     current_gitlab_token, current_gitlab_host,
@@ -1015,7 +1016,7 @@ async def sub_agent(
         if user_email:
             headers_env = (
                 f"ANTHROPIC_CUSTOM_HEADERS="
-                f"{shlex.quote(f'x-openwebui-user-email: {user_email}')} "
+                f"{shlex.quote(f'x-openwebui-user-email: {header_safe(user_email)}')} "
             )
 
         if resume_session_id and cli == Cli.CLAUDE:

--- a/computer-use-server/security.py
+++ b/computer-use-server/security.py
@@ -10,6 +10,25 @@ from fastapi import HTTPException
 
 CHAT_ID = re.compile(r"^[a-z0-9_-]{1,64}$")
 
+# Characters that terminate or split a header value. A header value cannot
+# legitimately contain any of them, so stripping is safe regardless of how the
+# downstream consumer parses -- which matters here because the consumer is
+# Claude Code inside the guest, and its splitting rule is not defined in this
+# repository (#603).
+_HEADER_UNSAFE = re.compile(r"[\r\n\x00]")
+
+
+def header_safe(value: str) -> str:
+    """Strip characters that could add or truncate a header.
+
+    Applied where a request-supplied value is interpolated into a header the
+    guest sends upstream. It is deliberately a STRIP rather than a rejection:
+    the caller is building a diagnostic tagging header, and failing a whole
+    session because a display name contained a newline would be a worse
+    outcome than tagging it with the newline removed.
+    """
+    return _HEADER_UNSAFE.sub("", value)
+
 
 def sanitize_chat_id(chat_id: str) -> str:
     """Validate chat_id against a character class, not a list of bad characters.

--- a/tests/orchestrator/test_header_safe.py
+++ b/tests/orchestrator/test_header_safe.py
@@ -1,0 +1,84 @@
+# SPDX-License-Identifier: FSL-1.1-Apache-2.0
+# Copyright (c) 2025 Open Computer Use Contributors
+"""A request-supplied value cannot add a header to an upstream call.
+
+x-user-email arrives from the request unvalidated (mcp_tools:1322) and is
+interpolated into ANTHROPIC_CUSTOM_HEADERS, a header LIST that Claude Code
+parses inside the guest (#603).
+
+Shell injection was already closed on both paths and this does not change
+that: the sub-agent path shlex.quote's the assignment, and the entrypoint
+exports the variable quoted. Both were checked rather than assumed. What was
+open is one layer up -- a separator inside the VALUE.
+
+header_safe strips rather than rejects, deliberately. The header is diagnostic
+tagging; failing a whole session because a display name carried a newline
+would be a worse outcome than tagging it with the newline gone. The tests
+below say so, so the choice is visible rather than looking like a half
+measure.
+
+The consumer's splitting rule is not defined in this repository, so the fix
+does not depend on knowing it: CR, LF and NUL cannot legitimately appear in a
+header value under any parser.
+"""
+
+import sys
+import unittest
+from pathlib import Path
+
+ROOT = Path(__file__).resolve().parent.parent.parent
+sys.path.insert(0, str(ROOT / "computer-use-server"))
+
+from security import header_safe  # noqa: E402
+
+
+class HeaderSafe(unittest.TestCase):
+    def test_an_ordinary_email_is_untouched(self):
+        """The bound must not damage the values it exists to carry."""
+        for value in ("user@example.com", "First Last", "ünïcode@example.com"):
+            with self.subTest(value=value):
+                self.assertEqual(header_safe(value), value)
+
+    def test_crlf_cannot_survive(self):
+        """The injection shape: a second header appended to the value."""
+        result = header_safe("a@b.c\r\nx-api-key: stolen")
+        self.assertNotIn("\r", result)
+        self.assertNotIn("\n", result)
+
+    def test_a_bare_newline_cannot_survive(self):
+        self.assertNotIn("\n", header_safe("a@b.c\nx-forwarded-for: 1.2.3.4"))
+
+    def test_nul_cannot_survive(self):
+        """A NUL truncates the value for a C-string consumer."""
+        self.assertNotIn("\x00", header_safe("a@b.c\x00ignored"))
+
+    def test_it_strips_rather_than_rejects(self):
+        """Stated as a test so the choice is a decision, not an oversight.
+
+        The remaining text is kept: a diagnostic tagging header should degrade
+        to a slightly wrong tag rather than fail the session.
+        """
+        self.assertEqual(header_safe("a@b.c\r\nx: y"), "a@b.cx: y")
+
+    def test_an_empty_value_stays_empty(self):
+        self.assertEqual(header_safe(""), "")
+
+    def test_both_interpolation_sites_use_it(self):
+        """The function is worthless if a caller forgets it.
+
+        Asserted against the source: both places that build
+        ANTHROPIC_CUSTOM_HEADERS must pass the value through header_safe.
+        """
+        for name in ("docker_manager.py", "mcp_tools.py"):
+            source = (ROOT / "computer-use-server" / name).read_text(encoding="utf-8")
+            for line in source.splitlines():
+                if "x-openwebui-user-email:" in line and "f\"" in line or "x-openwebui-user-email:" in line and "f'" in line:
+                    self.assertIn(
+                        "header_safe",
+                        line,
+                        f"{name} interpolates the email without header_safe",
+                    )
+
+
+if __name__ == "__main__":
+    unittest.main()


### PR DESCRIPTION
`x-user-email` arrives from the request **unvalidated** (`mcp_tools:1322`) and is interpolated into `ANTHROPIC_CUSTOM_HEADERS` — a header *list* that Claude Code parses inside the guest (#603).

## What was already closed, and what was not

Shell injection is closed on both paths, and this does not change that: the sub-agent path `shlex.quote`s the whole assignment, and the entrypoint exports the variable quoted. **I checked both rather than trusting the comment that says so**, and both hold.

What was open is one layer up: a separator inside the *value*.

## Why this half is pushed and the rest stays filed

The fix does not depend on knowing the consumer's splitting rule, which is not defined in this repository. **CR, LF and NUL cannot legitimately appear in a header value under any parser**, so stripping them is correct regardless.

Validating what the server *accepts* — the email-validation half of #603 — is a compatibility decision, so it stays filed.

## Strip, not reject — stated as a test

The header is diagnostic tagging. Failing a whole session because a display name carried a newline is a worse outcome than tagging it with the newline gone. A test says so, so the choice reads as a decision rather than a half measure.

## One test asserts against the source

Both interpolation sites must call `header_safe`. A sanitiser is worthless if the next caller forgets it.

| Mutation | Result |
|---|---|
| `header_safe` becomes a no-op | 4 failures |
| `docker_manager` drops the call | 1 failure |
| restore | all seven pass |

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Security**
  * Improved protection for request-provided email values used in custom headers by removing unsafe control characters.
  * Helps prevent malformed or injected header data from reaching container environments and downstream tools.

* **Tests**
  * Added coverage for sanitizing carriage returns, line feeds, null characters, and ordinary values.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->