### PR TITLE
ci: run the openwebui function tests, which ran nowhere

### DIFF
--- a/.github/workflows/orchestrator-tests.yml
+++ b/.github/workflows/orchestrator-tests.yml
@@ -60,3 +60,14 @@ jobs:
 
       - name: Run orchestrator pytest
         run: pytest tests/orchestrator/ -v
+
+      # openwebui/functions carries its own pytest file and nothing ran it:
+      # no workflow referenced it, and shell-tests -- which watches
+      # openwebui/** -- drives six named pytest files that do not include it.
+      # Ten assertions about the download-marker rewrite, including the
+      # fail-closed traversal refusal, executed nowhere.
+      #
+      # Run as a second step rather than folded into the path above, so a
+      # failure names which suite broke.
+      - name: Run openwebui function pytest
+        run: pytest openwebui/functions/ -v


### PR DESCRIPTION
`openwebui/functions` carries `test_computer_link_filter_download.py` — **ten assertions** about the download-marker rewrite, including the fail-closed traversal refusal and the percent-encoding of both the scope and the name.

**Nothing executed it.** No workflow references the file, and `shell-tests` — which watches `openwebui/**` — drives six *named* pytest files that do not include it. Verified by grepping `.github/` and `tests/` for the filename: no hit.

That is the same shape as the orchestrator suite before #589 — good tests written, never run — and it was found the same way: **by asking what runs a file, rather than whether the file exists.**

Added as a separate step rather than widening the existing path, so a failure names which suite broke.

## What I could not verify locally

The file imports `pytest` for its markers and this environment has none. The *subject* was checked by reading instead: `outlet` validates the marker name fail-closed — no separator, no traversal, no NUL, not `.` or `..` — and then percent-encodes both segments. That is a stronger pattern than several paths this repository has findings about.

CI will report whether the ten pass.

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Tests**
  * Added a dedicated test run for the functions suite.
  * Improved test output to make failures easier to identify.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->