### PR TITLE
ci: run tests/security, six pytest files that nothing collected

### DIFF
--- a/.github/workflows/orchestrator-tests.yml
+++ b/.github/workflows/orchestrator-tests.yml
@@ -71,3 +71,15 @@ jobs:
       # failure names which suite broke.
       - name: Run openwebui function pytest
         run: pytest openwebui/functions/ -v
+
+      # tests/security holds six pytest files -- 53 assertions about
+      # safe_path, path traversal in three call sites, XSS in the preview, and
+      # the scanner pin -- and nothing ran them. The two workflows that
+      # reference tests/security invoke SHELL scripts in that directory
+      # (sbom_guard.sh, check_cosign_identity_anchor.sh); the .py files were
+      # never collected.
+      #
+      # Found by asking what RUNS each test file rather than whether one
+      # exists, the same sweep that surfaced #615.
+      - name: Run security pytest
+        run: pytest tests/security/ -v


### PR DESCRIPTION
`tests/security` holds six pytest files — roughly **53 assertions** about `safe_path`, path traversal at three call sites, XSS in the preview, and the scanner version pin.

**Nothing ran them.**

The two workflows that mention `tests/security` invoke **shell scripts** in that directory — `sbom_guard.sh`, `check_cosign_identity_anchor.sh`. The `.py` files share the path and were never collected, which is why a grep for the directory *looks* like coverage and is not.

## How it was found

The sweep that surfaced #615: for every test file in the repository, ask **what runs it**. Twenty-one came back with no runner.

| tranche | files | assertions |
|---|---|---|
| `tests/security` | 6 | ~53 |
| `tests/patches` | 6 | ~48 |
| root `tests/*.py` | 5 | ~14 |
| `tests/integration` | 3 | runs in build.yml only, which is main-only (#491) |

This is the first tranche, and the one whose subject this repository already has open findings about.

## Not verified locally

The files import pytest and this environment has none — the same constraint as #615. CI will report. **If any fail, that is information worth having**: a test written and never executed has had no opportunity to be wrong.

The other tranches are left for separate commits, so a failure names which set broke.

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Tests**
  * Added an automated security test step to the continuous integration workflow.
  * Security tests now run with detailed output, improving visibility into security-related test results.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->