### PR TITLE
docs(openwebui): document DOWNLOAD_BASE_URL and DOWNLOAD_SCOPE

### DIFF
--- a/openwebui/functions/computer_link_filter.py
+++ b/openwebui/functions/computer_link_filter.py
@@ -94,6 +94,17 @@ CHANGELOG (v3.0.2):
             Label for the preview-button markdown link.
         ARCHIVE_BUTTON_TEXT (str, default "📦 Download all files as archive"):
             Label for the archive-download markdown link.
+        DOWNLOAD_BASE_URL (str, default ""):
+            Browser-facing base for [[ocu-download:NAME]] links. Empty means the
+            marker degrades to the bare filename as plain text rather than
+            minting a link that cannot resolve. Set by init.sh alongside
+            DOWNLOAD_SCOPE; the two are only useful together.
+        DOWNLOAD_SCOPE (str, default ""):
+            The {scope} path segment of a download link, and load-bearing rather
+            than decoration: the route is /download/{scope}/{filename} and a
+            one-segment link is a 404 (ADR-0035). Must equal the filesystem_id
+            claim the pane's session carries, so it comes from the portal rather
+            than from anything the model wrote. Empty degrades like the base.
 """
 
 import re


### PR DESCRIPTION
Both valves are defined on `Filter.Valves` and neither appeared in the module's `VALVES:` block.

`test_filter.py` has a drift guard that iterates the real `model_fields` and asserts each is documented. **It caught this the first time it was ever executed** — the file was collected by nothing until the sweep in #616.

That is the finding, not the fix: the guard existed and never ran.

## The scope entry says why it is load-bearing

Rather than restating its type: the route is `/download/{scope}/{filename}`, a one-segment link is a 404 (ADR-0035), and the value must equal the session's `filesystem_id` claim — so it comes from the portal, not from anything the model wrote.

## Probed the guard rather than trusting the green

Renaming the *docstring entry* did **not** fail it — correct, since the test reads `model_fields`, not prose. Adding a real undocumented field does fail it.

My first mutation was wrong, not the test.