### PR TITLE
chore: release v0.11.0.0 — rootless Podman sandboxes, Open WebUI base 0.11.0

### DIFF
--- a/.github/workflows/build.yml
+++ b/.github/workflows/build.yml
@@ -352,8 +352,20 @@ jobs:
     name: Integration — real MCP + Docker
     runs-on: ubuntu-latest
     # Catches what unit tests don't: auth wiring, tools/call dispatch, real
-    # container spawn, and label/mount plumbing. Production parity: we use
-    # the runner's host /var/run/docker.sock — identical to compose & helm.
+    # container spawn, and label/mount plumbing, against the runner's host
+    # /var/run/docker.sock.
+    #
+    # What this is parity WITH: the Docker API contract the orchestrator speaks,
+    # and the Compose layout a developer runs. Not with every deployment — an
+    # engine other than Docker can serve that same socket, and at least one
+    # deployment of this chart runs rootless Podman there instead
+    # (`podman system service` speaks the Docker API, which is why the
+    # orchestrator needs no code change either way).
+    #
+    # That difference is not academic: #435 and #436 were both defects that
+    # appeared only under an engine running without root, and neither was
+    # visible from the code or from this job. A green run here says the API
+    # contract holds, not that a rootless engine is exercised.
     needs: [build-sandbox, build-server]
     if: github.event_name != 'pull_request' || github.event.pull_request.head.repo.full_name == github.repository
     # The job depends on locally-tagged workspace + server images (the

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -24,13 +24,47 @@ Pre-release. Contents are the `v0.11.0.0` entry below, cut so the 0.11.0 base ca
 
 Images carry the `0.11.0.0-rc.1` tag: `ghcr.io/wide-moat/open-computer-use`, `-server`, `-cleanup`, `-webui`. `main` stays on `v0.10.2.0`; nothing about this pre-release changes the stable line.
 
-## v0.11.0.0 — bump Open WebUI base to 0.11.0 (unreleased)
+## v0.11.0.0 — rootless Podman sandboxes, Open WebUI base 0.11.0 (2026-08-23)
 
-Minor release: Open WebUI base bumped from `0.10.2` → `0.11.0`, 616 upstream commits. `middleware.py` changed by 1074 lines, but the output-based tool loop survived intact — `convert_output_to_messages` only moved its definition out of the module and is still imported there. Four of the five `fix_tool_loop_errors` anchors needed rebasing; the other four patches applied without anchor changes.
+Minor release, and the first to carry the sandbox runtime change: the inner container
+engine is now **rootless Podman** instead of Docker-in-Docker. Open WebUI base is bumped
+from `0.10.2` → `0.11.0`, 616 upstream commits. `middleware.py` changed by 1074 lines, but the output-based tool loop survived intact — `convert_output_to_messages` only moved its definition out of the module and is still imported there. Four of the five `fix_tool_loop_errors` anchors needed rebasing. The other four patches
+applied without anchor changes — which turned out to say less than it sounds: three of them
+carried defects that applying cleanly does not reveal, and those are fixed here too.
 
-The headline change is that upstream now handles tool-loop and code-interpreter errors itself.
+On the Open WebUI side the headline change is that upstream now handles tool-loop and
+code-interpreter errors itself.
 
 ### Changed
+
+- **Sandboxes run on rootless Podman instead of Docker-in-Docker.** The chart renders one
+  engine — a `quay.io/podman/stable:v5.3` sidecar (Podman Engine 5.3.2) serving the
+  Docker-compatible API — and there is nothing to select between: the `dind` container, the
+  `sandboxRuntime` switch and the `varLibDocker` PVC are gone. An older values file setting
+  `sandboxRuntime: docker` names a key no template reads.
+
+  What this removes from the cluster's side of the bargain:
+
+  - **No privileged container.** Docker-in-Docker required one; rootless Podman does not.
+  - **No RuntimeClass.** The default was `kata-qemu-heavy`, which most clusters do not have.
+    The chart now installs on a stock Kubernetes node.
+  - **No Block-mode PVC.** This one was not obvious and is the reason the other two could go:
+    the Block volume existed only because virtio-fs inside the Kata guest drops the
+    `security.capability` xattrs the sandbox image carries, so the image would not unpack on
+    ordinary storage. No guest, no virtio-fs, no requirement — verified, not assumed: the
+    9.47 GB image unpacks on plain filesystem storage with file capabilities intact.
+
+  **Isolation changes shape, and it is a reduction rather than a wash.** The Kata VM boundary
+  is replaced by user namespaces plus an AppArmor profile, set through
+  `podAnnotations` (`container.apparmor.security.beta.kubernetes.io/podman`). The profile has
+  to already exist on the node; a chart cannot install one, and without it the sandboxes are
+  confined only by the cluster's default profile. Clusters that have Kata and want the VM
+  boundary back can set `orchestrator.runtimeClassName` — but the Block-mode PVC has to come
+  back with it, because virtio-fs returns with the guest.
+
+  The orchestrator itself is unchanged. `podman system service` speaks the Docker API on the
+  same socket path, so `DOCKER_SOCKET` still reads `unix:///var/run/docker.sock` and the
+  Python Docker SDK talks to Podman without a code change.
 
 - **`openwebui/Dockerfile`** — `ARG OPENWEBUI_VERSION=0.10.2` → `0.11.0`.
 - **`fix_tool_loop_errors` no longer emits its own error banner.** 0.11.0 added `get_message_error_content()` and `emit_message_error()`, and calls both from the tool-loop and code-interpreter `except` blocks — the exact problem this patch was written for ("errors silently swallowed via `log.debug` + `break`"). Emitting our own `chat:message:error` on top would show the user two banners for one failure, so both modifications now call upstream's helper instead. That also gains something the patch never did: `emit_message_error()` persists the error to the chat, not just to the event stream. What stays ours is what upstream still does not do — restoring the text the user already saw before the failure, classifying transport faults into a "resend your message" hint, and rewriting the opaque "Model not found" into a budget-exhaustion message.
@@ -38,11 +72,42 @@ The headline change is that upstream now handles tool-loop and code-interpreter 
 - **`fix_tool_loop_errors` Mod 2 (code_interp)** — same `except` rework, and the chat-title lookup collapsed from a multi-line ternary guarded by a `channel:`-prefix check to a one-liner guarded by the new `save_to_chat` flag.
 - **`fix_tool_loop_errors` Mod 4 (done_bg)** — `ctx['assistant_message']` carries a `'content'` key again. It was dropped in 0.10.0 with `serialize_output()`; 0.11.0 rebuilds it from the streamed text (`''.join(content_parts) or get_output_text(output)`). Upstream also emits `publish_chat_finished_event` just above this block, so the wrap starts at the done-emit to avoid swallowing it.
 - **`fix_tool_loop_errors` Mod 5 (iter)** — the loop bound moved off the module constant onto a local `max_tool_call_iterations`, resolved per request as `getattr(request.state, 'max_tool_call_iterations', CHAT_RESPONSE_MAX_TOOL_CALL_ITERATIONS)`.
-- **Mod 3 (SSE) unchanged**, and `fix_large_tool_results`, `fix_attached_files_position`, `fix_skip_embedding_chat_files`, `fix_skip_rag_files_native_fc` needed no anchor edits.
+- **Mod 3 (SSE) unchanged**, and `fix_attached_files_position` needed no anchor edits. `fix_large_tool_results`, `fix_skip_embedding_chat_files` and `fix_skip_rag_files_native_fc` applied cleanly against 0.11.0 but were each wrong in a way applying cleanly does not reveal — see **Fixed** below.
 - **Test fixtures** replaced with byte-identical `v0.11.0` extracts (`middleware_v0.11.0.py`, `retrieval_v0.11.0.py`); `conftest.py`, `fixtures/__init__.py` and the `V0102` identifiers across the five suites renamed to match.
 - **Version pins refreshed**: `docker-compose.webui.yml`, `.env.example`, `README.md`, `openwebui/README.md`, `openwebui/patches/README.md`, `docs/openwebui-filter.md`, `helm/computer-use-server/Chart.yaml` `appVersion`, `examples/helm/with-open-webui/values-open-webui.yaml` `tag`, and the `Target:` line in every patch docstring.
 
 ### Fixed
+
+- **`fix_large_tool_results` truncated tool results after the frontend had already been sent
+  them.** Mod 2 anchored on `_saved_output`/`new_form_data`, code inserted by
+  `fix_tool_loop_errors`. In `middleware_v0.11.0.py` the `chat:completion` emit that sends the
+  results to the UI and persists them is at line 5217; that anchor is at 5223. Worse, being
+  attached to the `new_form_data` block, the truncation did not run **at all** when the model
+  answered immediately after a tool call and the loop exited — the common case for a single
+  large `fetch_url`. The anchor now sits on upstream's own "Append a new empty message item"
+  line, ahead of the emit.
+
+  Two things follow. The patch no longer depends on `fix_tool_loop_errors` running first,
+  because it anchors on upstream code rather than another patch's marker; the Dockerfile
+  comment saying otherwise is gone. And a regression test asserts the injection point precedes
+  the emit — the failure was silent in both directions (the patch reported success either way),
+  so the position is asserted rather than the exit code.
+
+- **`fix_skip_embedding_chat_files` injected code that cannot run on 0.10.x or later.** The
+  knowledge-base fallback built its extractor as `Loader(engine=request.app.state.config…)`
+  across some thirty keyword arguments. `app.state.config` was removed upstream — the 0.11.0
+  retrieval source contains zero occurrences — so the fallback would raise on first use.
+  `compile()` cannot see this, which is why it survived a base bump that re-audited every
+  anchor. It now uses upstream's own `get_loader_config()` + `build_loader_from_config()`, both
+  already imported in the target module.
+
+- **`fix_skip_rag_files_native_fc` hid attached notes, chats and URLs from the model.** When
+  the Computer Use tool is enabled the patch skips the RAG pipeline for ordinary files, keeping
+  only items with `context == 'full'`. But upstream's `get_sources_from_items()` dispatches on
+  six types — `text`, `note`, `chat`, `url`, `file`, `collection` — and only `file` has a
+  sandbox equivalent the model can read off disk. Everything else the user attached was dropped
+  silently, with no error and nothing in the log. The filter now keeps any item whose type is
+  not `file`.
 
 - **`server.json` was three base bumps stale** — the MCP registry manifest still declared `0.8.12.6`. Nothing in the repo reads it, which is how it drifted unnoticed since the 0.9.2 bump.
 - **`CLAUDE.md` still described the version scheme as `v0.9.X.Y`** and used `v0.9.5.0` as its worked example, two bases after that stopped being true.
@@ -50,7 +115,7 @@ The headline change is that upstream now handles tool-loop and code-interpreter 
 ### Verified
 
 - Cumulative dry-run in `openwebui/Dockerfile` order against a fresh `v0.11.0` source tree: all five backend patches apply, re-run clean (`ALREADY PATCHED`), both resulting files pass `ast.parse`, and the patched middleware carries exactly one error-banner emit in the tool-loop `except` — the duplicate-banner regression the `emit_message_error` rework exists to avoid.
-- `pytest tests/patches/` — 30 passed against the new fixtures.
+- `pytest tests/patches/` — 31 passed against the new fixtures, including the new anchor-position regression test. That test was itself checked by restoring the old anchor and confirming it fails.
 - Image build of `open-webui-ocu:0.11.0.0-rc.1` succeeds with all seven hard-fail guards green; every marker present in the built layers and both patched Python files parse inside the image.
 - Runtime: container boots, `/api/version` returns `0.11.0`, `/health` returns `{"status":true}`, `init.sh` completes its whole sequence with zero tracebacks. Every endpoint it calls is still present in the 0.11.0 routers, so it needs no change.
 - Browser end-to-end for both frontend chunk patches, with the chat seeded through the REST API rather than generated by a model — no LLM, so the check is reproducible without a provider key. Opening a chat whose assistant message contains an `html` code block opens the Artifacts panel unprompted and the iframe renders the page (`<h1>` reads `PATCH OK`); a chat containing a bare `/files/` URL produces the preview iframe. Zero console errors originate from the patched chunks. This matters more than usual here: `Chat.svelte` changed by 1106 lines and both patches rewrite minified bundles by regex, so "the patch applied" and "the behaviour survived" were genuinely separate questions.

--- a/docker-compose.test.yml
+++ b/docker-compose.test.yml
@@ -22,10 +22,15 @@ services:
     ports:
       - "18081:8081"  # non-default to avoid clashing with a running prod stack
     volumes:
-      # Production parity: bind the host Docker socket so the orchestrator
-      # spawns sibling containers on the host daemon. This is exactly the
-      # configuration the chart targets via Sysbox DinD in k8s and what the
-      # default Compose layout uses on a developer workstation.
+      # Bind the host Docker socket so the orchestrator spawns sibling
+      # containers on the host daemon — the same shape the default Compose
+      # layout uses on a developer workstation.
+      #
+      # The socket path is the contract, not the engine behind it: the
+      # orchestrator talks to whatever serves /var/run/docker.sock, and a
+      # rootless `podman system service` serves the same API. Deployments
+      # differ on which one that is; this file pins Docker because that is
+      # what a GitHub runner has.
       - /var/run/docker.sock:/var/run/docker.sock
       - ./tests/integration/_tmp/user-data:/tmp/computer-use-data:rw
     environment:

--- a/openwebui/Dockerfile
+++ b/openwebui/Dockerfile
@@ -16,7 +16,6 @@ RUN python3 /tmp/patches/fix_tool_loop_errors.py
 RUN python3 /tmp/patches/fix_preview_url_detection.py
 
 # Optional: Truncate large MCP tool results to prevent context window exhaustion.
-# Requires fix_tool_loop_errors.py to be applied first.
 # Config: TOOL_RESULT_MAX_CHARS (default 50000), TOOL_RESULT_PREVIEW_CHARS (default 2000)
 RUN python3 /tmp/patches/fix_large_tool_results.py
 

--- a/openwebui/patches/fix_large_tool_results.py
+++ b/openwebui/patches/fix_large_tool_results.py
@@ -161,34 +161,28 @@ def _truncate_tool_messages_in_history(messages: list) -> None:
 # === END PATCH: _truncate_large_results_in_output ===
 '''
 
-# Search pattern: targets code AFTER fix_tool_loop_errors.py (TOOL_LOOP_ERRORS_UNIFIED marker).
-# v0.9.2: Patch 3's REPLACE now emits `'metadata': metadata,` inside new_form_data — include it
-# in the SEARCH so the cascade region is fully covered and any upstream drift of the metadata
-# key fails loud here rather than silently producing a broken middleware.
+# Search pattern: upstream's own "append a new empty message item" line, which sits directly
+# after the tool results are appended to `output` and BEFORE the `chat:completion` emit that
+# sends them to the frontend and persists them.
+#
+# This anchor used to be `_saved_output`/`new_form_data`, i.e. code inserted by
+# fix_tool_loop_errors. That put truncation one turn too late: against
+# tests/patches/fixtures/middleware_v0.11.0.py the emit is at line 5217 and `new_form_data` at
+# 5223, so full results reached the UI and the DB regardless. Worse, being attached to the
+# `new_form_data` block, it did not run AT ALL when the model answered immediately after a
+# tool call and the loop exited -- the common case for a single large `fetch_url`.
+#
+# Anchoring on upstream code also drops the ordering dependency on fix_tool_loop_errors.
 SEARCH_TOOL_LOOP = (
-    "                    _saved_output = json.loads(json.dumps(output))"
-    "  # TOOL_LOOP_ERRORS_UNIFIED: save for restore on error\n"
-    "                    try:\n"
-    "                        new_form_data = {\n"
-    "                            **form_data,\n"
-    "                            'model': model_id,\n"
-    "                            'stream': True,\n"
-    "                            'metadata': metadata,\n"
-    "                        }\n"
+    "                    # Append a new empty message item for the next response\n"
+    "                    output.append(\n"
 )
 
 REPLACE_TOOL_LOOP = (
     "                    await _truncate_large_results_in_output("
-    "output, metadata.get('chat_id', ''))  # LARGE_TOOL_RESULTS\n"
-    "                    _saved_output = json.loads(json.dumps(output))"
-    "  # TOOL_LOOP_ERRORS_UNIFIED: save for restore on error\n"
-    "                    try:\n"
-    "                        new_form_data = {\n"
-    "                            **form_data,\n"
-    "                            'model': model_id,\n"
-    "                            'stream': True,\n"
-    "                            'metadata': metadata,\n"
-    "                        }\n"
+    "output, metadata.get('chat_id', ''))  # LARGE_TOOL_RESULTS: MARKER_MOD2_BEFORE_EMIT\n"
+    "                    # Append a new empty message item for the next response\n"
+    "                    output.append(\n"
 )
 
 
@@ -251,17 +245,17 @@ def apply_patch():
     content = content[:eol_idx] + FUNCTION_CODE + content[eol_idx:]
     print("  [1/3] Injected functions: _truncate_large_results_in_output, _truncate_tool_messages_in_history, _upload_result_to_docker_ai")
 
-    # Mod 2: Add truncation call before _saved_output in tool loop
+    # Mod 2: truncate current tool results before they are emitted to the frontend
     if SEARCH_TOOL_LOOP not in content:
         print(
-            "ERROR: fix_large_tool_results Mod 2 anchor (TOOL_LOOP_ERRORS_UNIFIED marker) "
-            "not found. Run fix_tool_loop_errors.py first, or upstream tool-loop structure "
-            "changed. Refusing to produce a silently-broken image.",
+            "ERROR: fix_large_tool_results Mod 2 anchor (upstream 'Append a new empty "
+            "message item' line) not found. Upstream tool-loop structure changed. "
+            "Refusing to produce a silently-broken image.",
             file=sys.stderr,
         )
         sys.exit(1)
     content = content.replace(SEARCH_TOOL_LOOP, REPLACE_TOOL_LOOP, 1)
-    print("  [2/3] Tool loop: truncate current results before _saved_output")
+    print("  [2/3] Tool loop: truncate current results before frontend emit")
 
     # Mod 3: Truncate historical tool messages from DB
     if SEARCH_HISTORY not in content:

--- a/openwebui/patches/fix_skip_embedding_chat_files.py
+++ b/openwebui/patches/fix_skip_embedding_chat_files.py
@@ -101,43 +101,18 @@ REPLACE_PATTERN_2 = """                else:
                         # async process_file handler doesn't block the OWUI event
                         # loop while the file is read from the storage backend.
                         _fb_path = await asyncio.to_thread(Storage.get_file, file.path)
-                        _fb_loader = Loader(
-                            engine=request.app.state.config.CONTENT_EXTRACTION_ENGINE,
-                            user=user,
-                            DATALAB_MARKER_API_KEY=request.app.state.config.DATALAB_MARKER_API_KEY,
-                            DATALAB_MARKER_API_BASE_URL=request.app.state.config.DATALAB_MARKER_API_BASE_URL,
-                            DATALAB_MARKER_ADDITIONAL_CONFIG=request.app.state.config.DATALAB_MARKER_ADDITIONAL_CONFIG,
-                            DATALAB_MARKER_SKIP_CACHE=request.app.state.config.DATALAB_MARKER_SKIP_CACHE,
-                            DATALAB_MARKER_FORCE_OCR=request.app.state.config.DATALAB_MARKER_FORCE_OCR,
-                            DATALAB_MARKER_PAGINATE=request.app.state.config.DATALAB_MARKER_PAGINATE,
-                            DATALAB_MARKER_STRIP_EXISTING_OCR=request.app.state.config.DATALAB_MARKER_STRIP_EXISTING_OCR,
-                            DATALAB_MARKER_DISABLE_IMAGE_EXTRACTION=request.app.state.config.DATALAB_MARKER_DISABLE_IMAGE_EXTRACTION,
-                            DATALAB_MARKER_FORMAT_LINES=request.app.state.config.DATALAB_MARKER_FORMAT_LINES,
-                            DATALAB_MARKER_USE_LLM=request.app.state.config.DATALAB_MARKER_USE_LLM,
-                            DATALAB_MARKER_OUTPUT_FORMAT=request.app.state.config.DATALAB_MARKER_OUTPUT_FORMAT,
-                            EXTERNAL_DOCUMENT_LOADER_URL=request.app.state.config.EXTERNAL_DOCUMENT_LOADER_URL,
-                            EXTERNAL_DOCUMENT_LOADER_API_KEY=request.app.state.config.EXTERNAL_DOCUMENT_LOADER_API_KEY,
-                            TIKA_SERVER_URL=request.app.state.config.TIKA_SERVER_URL,
-                            DOCLING_SERVER_URL=request.app.state.config.DOCLING_SERVER_URL,
-                            DOCLING_API_KEY=request.app.state.config.DOCLING_API_KEY,
-                            DOCLING_PARAMS=request.app.state.config.DOCLING_PARAMS,
-                            PDF_EXTRACT_IMAGES=request.app.state.config.PDF_EXTRACT_IMAGES,
-                            PDF_LOADER_MODE=request.app.state.config.PDF_LOADER_MODE,
-                            DOCUMENT_INTELLIGENCE_ENDPOINT=request.app.state.config.DOCUMENT_INTELLIGENCE_ENDPOINT,
-                            DOCUMENT_INTELLIGENCE_KEY=request.app.state.config.DOCUMENT_INTELLIGENCE_KEY,
-                            DOCUMENT_INTELLIGENCE_MODEL=request.app.state.config.DOCUMENT_INTELLIGENCE_MODEL,
-                            MISTRAL_OCR_API_BASE_URL=request.app.state.config.MISTRAL_OCR_API_BASE_URL,
-                            MISTRAL_OCR_API_KEY=request.app.state.config.MISTRAL_OCR_API_KEY,
-                            MINERU_API_MODE=request.app.state.config.MINERU_API_MODE,
-                            MINERU_API_URL=request.app.state.config.MINERU_API_URL,
-                            MINERU_API_KEY=request.app.state.config.MINERU_API_KEY,
-                            MINERU_API_TIMEOUT=request.app.state.config.MINERU_API_TIMEOUT,
-                            MINERU_PARAMS=request.app.state.config.MINERU_PARAMS,
-                        )
-                        # Loader.load is sync and CPU/IO-bound (PyMuPDF, Unstructured,
-                        # Tika, etc.) — minutes for large files. aload() is the
-                        # upstream-provided async wrapper that offloads via
-                        # asyncio.to_thread, keeping the event loop responsive.
+                        _fb_loader_config = await get_loader_config()
+                        _fb_loader = build_loader_from_config(request, _fb_loader_config)
+                        _fb_loader.user = user
+                        _fb_loader.metadata = {
+                            'file_id': file.id,
+                            'file_name': file.filename,
+                            'file_content_type': file.meta.get('content_type'),
+                        }
+                        # aload() is upstream's async wrapper: the underlying load is
+                        # sync and CPU/IO-bound (PyMuPDF, Unstructured, Tika, etc.) and
+                        # takes minutes on large files, so it offloads via
+                        # asyncio.to_thread and keeps the event loop responsive.
                         docs = await _fb_loader.aload(
                             file.filename, file.meta.get('content_type'), _fb_path
                         )

--- a/openwebui/patches/fix_skip_rag_files_native_fc.py
+++ b/openwebui/patches/fix_skip_rag_files_native_fc.py
@@ -9,7 +9,8 @@ Problem: Chat files always trigger the RAG pipeline
 (chat_completion_files_handler) on every message, even when unnecessary.
 
 Solution: When ai_computer_use is enabled, skip RAG for regular files.
-Full-context files (context == "full") are processed normally.
+Full-context files (context == "full") and non-file items (notes, chats,
+URLs, text, collections) are processed normally.
 Knowledge bases are not affected.
 """
 
@@ -34,13 +35,24 @@ SEARCH_PATTERN = """    if file_context_enabled:
 REPLACE_PATTERN = """    if file_context_enabled:
         # PATCH: skip_rag_files_ai_computer_use; FIX_SKIP_RAG_FILES_NATIVE_FC
         # When ai_computer_use is enabled, skip RAG for regular files.
-        # Full-context files (context == "full") are processed normally.
+        # Full-context files and non-file items (notes, chats, URLs, text,
+        # collections) are processed normally.
         # NB: tools_dict keys are function names from tool specs,
         # not tool IDs. bash_tool is a function from ai_computer_use tool.
         if 'bash_tool' in tools_dict:
             _all_files = form_data.get('metadata', {}).get('files', None)
             if _all_files:
-                _full_ctx = [f for f in _all_files if f.get('context') == 'full']
+                # Keep everything that is not a plain uploaded file — notes, chats, URLs,
+                # text and collections are context the user attached deliberately, and
+                # the sandbox cannot read them off disk the way it reads a file. Only
+                # type == 'file' is skipped, and then only when it is not full-context.
+                # Filtering on context alone dropped them silently: upstream
+                # get_sources_from_items() dispatches on six types (text, note, chat,
+                # url, file, collection) and only 'file' has a sandbox equivalent.
+                _full_ctx = [
+                    f for f in _all_files
+                    if f.get('type') != 'file' or f.get('context') == 'full'
+                ]
                 if _full_ctx:
                     _orig = form_data['metadata']['files']
                     form_data['metadata']['files'] = _full_ctx

--- a/tests/patches/test_fix_large_tool_results.py
+++ b/tests/patches/test_fix_large_tool_results.py
@@ -36,8 +36,8 @@ class TestPatchApplication(unittest.TestCase):
 
         Must include:
         - `from open_webui.models.chats import Chats` (Mod 1 import marker)
-        - SEARCH_TOOL_LOOP literal (TOOL_LOOP_ERRORS_UNIFIED save-for-restore marker
-          + `\n                    try:\n                        new_form_data = {\n`)
+        - SEARCH_TOOL_LOOP literal (upstream's "Append a new empty message item"
+          comment + `output.append(`)
         - SEARCH_HISTORY literal (process_messages_with_output + sanitize_tool_pairs
           + blank + get_system_message)
         """
@@ -72,14 +72,10 @@ class TestPatchApplication(unittest.TestCase):
             "    tool_call_retries = 0\n"
             "    while tool_call_retries < 5:\n"
             "        tool_call_retries += 1\n"
-            "                    _saved_output = json.loads(json.dumps(output))  # TOOL_LOOP_ERRORS_UNIFIED: save for restore on error\n"
-            "                    try:\n"
-            "                        new_form_data = {\n"
-            "                            **form_data,\n"
-            "                            'model': model_id,\n"
-            "                            'stream': True,\n"
-            "                            'metadata': metadata,\n"
-            "                        }\n"
+            "                    # Append a new empty message item for the next response\n"
+            "                    output.append(\n"
+            "                        {'type': 'message'}\n"
+            "                    )\n"
         )
 
     def test_patch_applies_successfully(self):
@@ -452,12 +448,35 @@ class TestFixLargeToolResultsV0110(unittest.TestCase):
         self.assertIn("ERROR:", r.stderr)
         self.assertIn(self.PATCH_NAME, r.stderr)
 
-    def test_patch_fails_loud_without_fix_tool_loop_errors(self):
-        # Mod 2 anchors on the TOOL_LOOP_ERRORS_UNIFIED marker, which only
-        # exists once fix_tool_loop_errors has run.
+    def test_applies_without_fix_tool_loop_errors(self):
+        # Mod 2 anchors on upstream code, not on another patch's marker, so it
+        # no longer depends on fix_tool_loop_errors having run first.
         r = _run_patch("fix_large_tool_results", self.target)
-        self.assertEqual(r.returncode, 1, f"stdout={r.stdout} stderr={r.stderr}")
-        self.assertIn("fix_tool_loop_errors", r.stderr.lower())
+        self.assertEqual(r.returncode, 0, f"stdout={r.stdout} stderr={r.stderr}")
+        self.assertIn("_truncate_large_results_in_output", self.target.read_text())
+
+    def test_truncates_before_model_sees_result(self):
+        """Mod 2 must run BEFORE the results are emitted to the frontend.
+
+        Regression test for the anchor this patch used to carry. Anchored on
+        `new_form_data`, truncation ran after the `chat:completion` emit had
+        already sent the full result to the UI and persisted it -- and did not
+        run at all when the model answered immediately after a tool call and
+        the loop exited. Both are silent: the patch reports success either way,
+        which is why the position is asserted rather than the exit code.
+        """
+        _run_patch("fix_tool_loop_errors", self.target)
+        r = _run_patch(self.PATCH_NAME, self.target)
+        self.assertEqual(r.returncode, 0, f"stdout={r.stdout} stderr={r.stderr}")
+        content = self.target.read_text()
+
+        call = content.index("await _truncate_large_results_in_output(output")
+        emit = content.index("'output': frontend_output")
+        self.assertLess(
+            call, emit,
+            "truncation must be injected before the frontend emit, otherwise the "
+            "full result reaches the UI and the DB regardless",
+        )
 
 
 if __name__ == "__main__":


### PR DESCRIPTION
Production runs the Open WebUI **0.9.6** base, not 0.11. Verified in the pod rather than in git:

```
$ kubectl exec -n prod owui-prod-0 -- cat /app/package.json
"version": "0.9.6"
$ ls /app/backend/open_webui/utils/context_compaction.py
No such file or directory
```

`main` has carried the 0.11.0 bump since `376e558` and is 71 commits ahead of the image prod
runs. The work was done and never released. This cuts it.

## What ships

**Rootless Podman**, which appears nowhere in the changelog today (`grep -i podman CHANGELOG.md`
returns nothing) despite being live in both environments. No privileged container, no
RuntimeClass, no Block-mode PVC — the last of those went away because virtio-fs inside the Kata
guest was the only reason it existed. Isolation drops from a VM boundary to user namespaces plus
AppArmor, and the entry says so rather than glossing it.

**Open WebUI base 0.10.2 → 0.11.0**, already implemented on `main`.

**Three patch defects**, found by comparing our patch set against an independent fork of the same
patches and then confirmed against our own fixtures:

| Patch | Defect |
|---|---|
| `fix_large_tool_results` | Mod 2 truncated *after* the frontend emit (5223 vs 5217), and not at all when the model answered immediately after a tool call |
| `fix_skip_embedding_chat_files` | Injected `request.app.state.config`, removed upstream in 0.10.x — zero occurrences in the 0.11.0 source |
| `fix_skip_rag_files_native_fc` | Kept only `context == 'full'`, silently dropping attached notes, chats and URLs |

All three applied cleanly and reported success, which is why a base bump that re-audited every
anchor did not catch them.

## Verification

- `pytest tests/patches/` — 31 passed.
- The new anchor-position regression test was itself checked: restoring the old anchor makes it
  fail with `235202 not less than 235075`. A test that cannot fail is not a test.
- Cumulative dry-run in `openwebui/Dockerfile` order: all five backend patches apply, both
  resulting files pass `ast.parse`, and `app.state.config` occurs zero times in the result.
- Patch order reversed (`fix_large_tool_results` before `fix_tool_loop_errors`) also applies
  clean, confirming the ordering dependency is gone.

Not yet done — image build and the stage rollout follow once this merges and
`release.yml` runs.

🤖 Generated with [Claude Code](https://claude.com/claude-code)


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

- **New Features**
  - Updated the platform to Open WebUI 0.11.0.
  - Migrated container execution from Docker-in-Docker to rootless Podman.
  - Improved handling of large tool results before display.
  - Preserved notes, chats, URLs, text, and collections during retrieval-augmented generation.

- **Bug Fixes**
  - Improved knowledge-base file loading.
  - Fixed processing for non-file retrieval items.
  - Refined tool-loop error handling.

- **Tests**
  - Expanded verification for patch application, tool-result handling, image builds, runtime health, and browser behavior.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->