### PR TITLE
ci(chart): pass secrets.create with the placeholder key, or the oneOf rejects it

### DIFF
--- a/.github/workflows/release-chart.yml
+++ b/.github/workflows/release-chart.yml
@@ -124,10 +124,17 @@ jobs:
 
       - name: helm lint (sanity)
         run: |
-          # Lint with a placeholder API key — schema requires either mcpApiKey
-          # or existingSecret to be non-empty; we're not publishing values.yaml
-          # so this is purely a schema-level check.
+          # Lint with placeholder values — the schema requires either
+          # (secrets.create=true AND mcpApiKey) or existingSecret, and rejects a
+          # half-filled first branch. Passing mcpApiKey alone fails the oneOf,
+          # which is the schema doing its job rather than a chart problem.
+          #
+          # storageClass is required too, but by `required` in the PVC templates
+          # rather than by the schema, so `helm lint` never reaches it — it
+          # validates values without rendering. `helm template` in helm.yml is
+          # where that one is checked.
           helm lint "${{ env.CHART_PATH }}" \
+            --set secrets.create=true \
             --set secrets.mcpApiKey=lint-only \
             --set orchestrator.env.PUBLIC_BASE_URL=https://lint.example.com
 


### PR DESCRIPTION
The `v0.11.0.1` chart publish failed at its sanity lint:

```
[ERROR] values.yaml: - secrets: Must validate one and only one schema (oneOf)
- secrets.create: secrets.create does not match: true
```

Not a chart problem — the schema doing its job. It accepts either `(create=true AND mcpApiKey)` or `existingSecret`, and rejects a half-filled first branch. The step passed `mcpApiKey` alone, which satisfies neither.

This surfaced now because the Podman chart brought its stricter `values.schema.json` with it; the previous chart's schema let the half-filled branch through. The step itself is unchanged since #415.

Also recorded in the comment: `storageClass` is required too, but by `required` in the PVC templates rather than by the schema, so `helm lint` never reaches it — it validates values without rendering. That check lives on `helm template` in `helm.yml`.

**Verified locally:** lint clean with the added flag, and `helm package` produces `computer-use-server-0.4.0.tgz`.

🤖 Generated with [Claude Code](https://claude.com/claude-code)

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Bug Fixes**
  * Improved Helm chart validation by including the required secrets configuration during linting.
  * Clarified validation guidance for secrets and storage class settings.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->