### PR TITLE
chore(helm): point chart defaults at 0.11.0.1

### DIFF
--- a/helm/computer-use-server/Chart.yaml
+++ b/helm/computer-use-server/Chart.yaml
@@ -10,7 +10,7 @@ description: |
   release when needed; see examples/helm/with-open-webui/.
 type: application
 version: 0.4.0
-appVersion: "0.11.0.0"
+appVersion: "0.11.0.1"
 kubeVersion: ">=1.27.0-0"
 home: https://github.com/Wide-Moat/open-computer-use
 sources:

--- a/helm/computer-use-server/values.yaml
+++ b/helm/computer-use-server/values.yaml
@@ -31,7 +31,7 @@ image:
   # -- Orchestrator image (the FastAPI server in computer-use-server/).
   repository: ghcr.io/wide-moat/open-computer-use-server
   # AppVersion 0.9.5.0-rc.2 — image-tag bump, chart unchanged (2 local patches still apply).
-  tag: "0.9.5.0-rc.2"
+  tag: "0.11.0.1"
   pullPolicy: IfNotPresent
 
 # Workspace image — the AI sandbox the orchestrator spawns via the Podman sidecar. Pulled by
@@ -39,7 +39,7 @@ image:
 # and is not covered by imagePullSecrets.
 workspaceImage:
   repository: ghcr.io/wide-moat/open-computer-use
-  tag: "0.9.5.0-rc.2"
+  tag: "0.11.0.1"
 
 # -- imagePullSecrets are applied to the Pod for the orchestrator and engine images.
 imagePullSecrets: []
@@ -173,7 +173,7 @@ cleanup:
   enabled: true
   image:
     repository: ghcr.io/wide-moat/open-computer-use-cleanup
-    tag: "0.9.5.0-rc.2"
+    tag: "0.11.0.1"
     pullPolicy: IfNotPresent
   containerMaxAgeHours: 24
   dataMaxAgeDays: 7


### PR DESCRIPTION
## Why now

The Podman chart has **never been published**. `release-chart.yml` failed on `helm lint`; #627 fixed that. So `0.4.0` will publish for the first time with whatever these defaults say — and they said `0.9.5.0-rc.2`.

Verified against GHCR:

| chart version | published |
|---|---|
| `0.11.0-rc.1` | yes — the old Docker-in-Docker chart |
| `0.3.0` | no |
| `0.4.0` (Podman) | **no** |

`0.9.5.0-rc.2` predates the rootless fixes (#435, #436). A fresh `helm install` off the published chart would start the Podman engine with a workspace image that cannot create a sandbox under it — indistinguishable, from outside, from the chart being broken.

## What changes

All four image references → `0.11.0.1`. `quay.io/podman/stable:v5.3` is left alone: it tracks the engine, not this release.

Images confirmed by direct manifest probe rather than tag listing — the listing serves cached data and has already reported "pending" for images that were live:

```
open-computer-use-server:0.11.0.1   HTTP 200
open-computer-use:0.11.0.1          HTTP 200
open-computer-use-cleanup:0.11.0.1  HTTP 200
```

Chart `version` stays `0.4.0` — nothing was published under it, so there is no released artifact to supersede.

## Evidence

`helm lint` with the flags `release-chart.yml` passes: `1 chart(s) linted, 0 chart(s) failed`.

`helm template` with the four storage classes `helm.yml` sets renders 453 lines:

| check | result |
|---|---|
| containers | `orchestrator`, `podman`, `cleanup` |
| `- name: dind` | 0 |
| `privileged: true` | 0 |
| `runtimeClassName` | 0 |
| `volumeMode: Block` | 0 |
| `DOCKER_IMAGE` | `ghcr.io/wide-moat/open-computer-use:0.11.0.1` |

The render was checked for a non-zero line count first: an empty render would have satisfied every zero above.

Two absences that are design, not defects — both stated in `values.yaml`:

- **workspace image is not a pod container.** Podman pulls it at first chat creation, so it reaches the orchestrator through `DOCKER_IMAGE` and never appears in `kubectl get pod`.
- **no AppArmor annotation by default.** The profile name belongs to the operator's nodes; the chart documents `podAnnotations` for it instead of naming one installation's profile.

## Not in scope

The cleanup sidecar's unset `DOCKER_HOST` (falls back to `tcp://docker:2375`, so containers outlive the 24h limit). Real, separate, and not made worse here.

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Chores**
  * Updated the application release version to 0.11.0.1.
  * Updated the orchestrator, workspace, and cleanup component images to version 0.11.0.1.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->